### PR TITLE
Pandoc enhancements - Add pandoc build script, fix logo/title ordering in HTML/PDF and better variable (metadata) substitution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /build/
 .vscode
 .DS_Store
+/*.html
+/*.pdf

--- a/acal-core-json-v1.0.md
+++ b/acal-core-json-v1.0.md
@@ -1,19 +1,24 @@
-![OASIS](http://docs.oasis-open.org/templates/OASISLogo-v3.0.png)
-
 ---
+# Document metadata processed by Pandoc:
+logo: |
+  ![OASIS](images/OASISLogo-v3.0.png)
+# Original logo: http://docs.oasis-open.org/templates/OASISLogo-v3.0.png
+title: JSON Representation of ACAL Version 1.0 (JACAL)
+subtitle: Committee Specification Draft 02
+version: "1.0"
+stage_revision: csd02 # [stage-abbrev][revisionNumber] as defined in https://docs.oasis-open.org/specGuidelines/ndr/namingDirectives.html
+lang: en
+keywords: ["access control", "authorization", "ABAC", "policy language", "JSON", "standard"]
+# date metadata is set automatically to current date, unless specified on pandoc commandline: --metadata date="..."
 
-# JSON Representation of ACAL Version 1.0 (JACAL)
-
-## Committee Specification Draft 01
-
-
-## 18 February 2026
+# If metadata 'x' is a string, any placeholder %x% will be replaced with the value of metadata 'x' (using meta_vars.lua filter), e.g. %version% will be replaced with the version metadata value.
+---
 
 ### This version
 
-- https://docs.oasis-open.org/xacml/acal/jacal/core/v1.0/csd01/acal-core-json-v1.0-csd01.html (Authoritative) 
-- https://docs.oasis-open.org/xacml/acal/jacal/core/v1.0/csd01/acal-core-json-v1.0-csd01.pdf
-- https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v1.0/csd01/acal-xpath-v1.0-csd01.md
+- https://docs.oasis-open.org/xacml/acal/jacal/core/v%version%/%stage_revision%/acal-core-json-v%version%-%stage_revision%.html (Authoritative) 
+- https://docs.oasis-open.org/xacml/acal/jacal/core/v%version%/%stage_revision%/acal-core-json-v%version%-%stage_revision%.pdf
+- https://docs.oasis-open.org/xacml/acal/jacal/core/v%version%/%stage_revision%/acal-core-json-v%version%-%stage_revision%.md
 
 
 ### Previous version
@@ -25,9 +30,9 @@ N/A
 ### Latest version
 
 
-- https://docs.oasis-open.org/xacml/acal/jacal/core/v1.0/csd01/acal-core-json-v1.0-csd01.html (Authoritative)
-- https://docs.oasis-open.org/xacml/acal/jacal/core/v1.0/csd01/acal-core-json-v1.0-csd01.pdf
-- https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v1.0/csd01/acal-xpath-v1.0-csd01.md
+- https://docs.oasis-open.org/xacml/acal/jacal/core/v1.0/acal-core-json-v1.0.html (Authoritative)
+- https://docs.oasis-open.org/xacml/acal/jacal/core/v1.0/acal-core-json-v1.0.pdf
+- https://docs.oasis-open.org/xacml/acal/jacal/core/v1.0/acal-xpath-v1.0.md
 
 
 ### Technical Committee:
@@ -52,8 +57,8 @@ N/A
 
 This document is one component of a Work Product that also includes:
 
-* Core JSON schema:  [acal-core-json-v1.0-schema.json](acal-core-json-v1.0-schema.json)
-* Short identifier set: [acal-core-json-v1.0-identifiers.json](acal-core-json-v1.0-identifiers.json)
+* [Core JSON schema](acal-core-json-v%version%-schema.json);
+* [Short identifier set](acal-core-json-v%version%-identifiers.json).
 
 <!-- Note: Any normative computer language definitions that are part of the Work Product, such as XML instances, schemas and Java(TM) code, including fragments of such, must be (a) well formed and valid, (b) provided in separate plain text files, (c) referenced from the Work Product; and (d) where any definition in these separate files disagrees with the definition found in the specification, the definition in the separate file prevails. Remove this note before submitting for publication.)
 -->
@@ -68,8 +73,8 @@ This specification defines Version 1.0 of the JSON Representation Profile of the
 When referencing this specification the following citation format should be used:
 
 **[JACAL-Core-1.0]**
-_ACAL v1.0 JSON Representation Profile (JACAL) Version 1.0_.
-Edited by Steven Legg and Cyril Dangerville. 18 February 2026. OASIS Committee Specification Draft 01. https://docs.oasis-open.org/xacml/acal/jacal/core/v1.0/csd01/acal-core-json-v1.0-csd01.html . Latest stage: https://docs.oasis-open.org/xacml/acal/jacal/core/v1.0/csd01/acal-core-json-v1.0-csd01.html.
+_%title%_.
+Edited by Steven Legg and Cyril Dangerville. %date%. OASIS %subtitle%. https://docs.oasis-open.org/xacml/acal/jacal/core/v%version%/%stage_revision%/acal-core-json-v%version%-%stage_revision%.html . Latest stage: https://docs.oasis-open.org/xacml/acal/jacal/core/v1.0/acal-core-json-v1.0.html.
 
 
 ### Related work:
@@ -370,7 +375,7 @@ The list of changes from the previous version and any revision history can be fo
 # 5 Syntax (normative, with the exception of the schema fragments)
 
 The next sections describe the rules that SHALL be applied for mapping the [[ACAL-Core-1.0](#acal-core-10)] agnostic model (UML-based) to [JSON schema Draft 2020-12](#jsonschemacore) definitions for this JSON representation (JACAL).
-These rules have been applied to produce JACAL's core JSON schema in [Annex D](#annex-d-json-schema-normative) (also in the [Core JSON schema file](acal-core-json-v1.0-schema.json) accompanying this document) from [[ACAL-Core-1.0](#acal-core-10)] core model.
+These rules have been applied to produce JACAL's core JSON schema in [Annex D](#annex-d-json-schema-normative) (also in the [Core JSON schema file](acal-core-json-v%version%-schema.json) accompanying this document) from [[ACAL-Core-1.0](#acal-core-10)] core model.
 
 We consider `PolicyType`, `BundleType`, `RequestType` and `ResponseType` as the root JSON objects to be used by JACAL users, therefore the final JACAL core schema has the following structure:
 
@@ -933,7 +938,7 @@ In this example, we consider an ACAL implementation that supports the `Attribute
 !include examples/acal-core-json/jacal-root-schema-example-using-jsonpath-profile-only.json
 ```
 
-This schema refers to (and therefore depends on) the [JSONPath Profile's JSON schema](acal-jsonpath-json-v1.0-schema.json) by its identifier `urn:oasis:names:tc:jacal:1.0:jsonpath:schema`, which is also provided by the XACML TC with the core schema.
+This schema refers to (and therefore depends on) the [JSONPath Profile's JSON schema](acal-jsonpath-json-v%version%-schema.json) by its identifier `urn:oasis:names:tc:jacal:1.0:jsonpath:schema`, which is also provided by the XACML TC with the core schema.
 
 
 ### 5.4.2 Example using extensions from multiple ACAL Profiles
@@ -944,7 +949,7 @@ In this example, we consider an ACAL implementation that supports various extens
 !include examples/acal-core-json/jacal-root-schema-example-using-xpath-and-jsonpath-profiles.json
 ```
 
-This schema refers to (and therefore depends on) to both the [JSONPath Profile's JSON schema](acal-jsonpath-json-v1.0-schema.json) by its identifier `urn:oasis:names:tc:jacal:1.0:jsonpath:schema` and [XPath Profile's JSON schema](acal-xpath-json-v1.0-schema.json) by its identifier `urn:oasis:names:tc:jacal:1.0:xpath:schema`, which are also provided by the XACML TC with the core schema.
+This schema refers to (and therefore depends on) to both the [JSONPath Profile's JSON schema](acal-jsonpath-json-v%version%-schema.json) by its identifier `urn:oasis:names:tc:jacal:1.0:jsonpath:schema` and [XPath Profile's JSON schema](acal-xpath-json-v%version%-schema.json) by its identifier `urn:oasis:names:tc:jacal:1.0:xpath:schema`, which are also provided by the XACML TC with the core schema.
 
 ### 5.4.3 Example combining a custom extension with a standard profile-defined extension
 
@@ -1350,12 +1355,10 @@ This section includes the JSON Schema for the JACAL syntax defined in this speci
 
 ## Prerequisites
 
-Install Pandoc on your system; or simply use Docker with the following shell alias:
+Install Pandoc **v3.2.1 or later** ( [latest release](https://github.com/jgm/pandoc/releases/latest) ) on your system; or simply use Docker with the following shell alias:
 ```
 $ alias pandoc='docker run --rm --volume "$(pwd):/data" pandoc/extra'
 ```
-
-OASIS staff are currently using pandoc 3.0 from https://github.com/jgm/pandoc/releases/tag/3.0.
 
 Git clone or get a local copy of [OASIS XACML TC Github repository](https://github.com/oasis-tcs/xacml-spec/), open a terminal and **change your working directory to the root directory of your local copy of the repository**.
 
@@ -1366,23 +1369,26 @@ The generation command uses a CSS stylesheet file (`-c` argument) provided by OA
 - https://docs.oasis-open.org/templates/css/markdown-styles-v1.7.3a.css (this one produces HTML that resembles the github display more closely, especially for blocks of code) This template already includes a reference (in HTML code) to this .css file.
 - https://docs.oasis-open.org/templates/css/markdown-styles-v1.8.1-cn_final.css
 
-## HTML generation
+### HTML generation
 
-Run the following command line to generate HTML from this markdown file (named `acal-core-json-v1.0-csd01.md`) to an output file `/tmp/acal-core-json-v1.0-csd01.html` :
-
-```console
-$ pandoc -s --embed-resources -f gfm+definition_lists -c styles/markdown-styles-v1.7.3a.css -F pandoc-include -M lang=en -M title=" " -t html -o /tmp/acal-core-json-v1.0-csd01.html acal-core-json-v1.0-csd01.md
-```
-
-Note this command generates a Table of Contents (TOC) in HTML which is located at the top of the HTML document, and which requires additional editing in order to be published in the expected OASIS style. This editing will be handled by OASIS staff during publication.
-
-## PDF generation
-
-For PDF output, the command line is the following (different `-t` and `-H` arguments, and output file `/tmp/acal-core-json-v1.0-csd01.pdf`):
+Run the following command line to generate the HTML from this markdown file (input file specified as last argument):
 
 ```console
-$ pandoc -s --embed-resources -f gfm+definition_lists -c styles/markdown-styles-v1.7.3a.css -F pandoc-include -H pandoc/custom_latex_header_for_pandoc_pdf_output.tex -M lang=en -M title=" " -t pdf -o /tmp/acal-core-json-v1.0-csd01.pdf acal-core-json-v1.0-csd01.md
+$ pandoc/mkdocs.sh --output /tmp acal-core-json-v%version%.md
 ```
+The `--output` option sets the output directory, and the output filename is the same as the input file (last argument) except `.md` extension is replaced with `.html`.
+
+The publication date is automatically set to the current date by default (using Lua filter `pandoc/meta_vars.lua`). However, you may set a specific date of your choice instead, by adding the argument `--metadata date="My date in the form DD Month YYYY"` at the end of the command. 
+
+### PDF generation
+
+For PDF output, add the `--pdf` option as follows:
+
+```console
+$ pandoc/mkdocs.sh --pdf --output /tmp acal-core-json-v%version%.md
+```
+
+The HTML file is generated like the previous command and, in addition, a PDF file is generated with the same name as the input file except the `.md` extension is replaced with `.pdf` in this case.
 
 -------
 
@@ -1464,7 +1470,7 @@ None. This is the first version of the document.
 
 ## Revision History
 
-Latest revision history can be obtained from [OASIS XACML TC's github repository](https://github.com/oasis-tcs/xacml-spec/blob/v1.0-csd01/acal-core-json-v1.0-csd01.md).
+Latest revision history can be obtained from [OASIS XACML TC's github repository](https://github.com/oasis-tcs/xacml-spec/blob/v%version%-%stage_revision%/acal-core-json-v%version%-%stage_revision%.md).
 
 <!--
 - \< Date in yyyy-mm-dd format \>, \< Revision number \>  

--- a/acal-core-v1.0.md
+++ b/acal-core-v1.0.md
@@ -5,20 +5,20 @@ logo: |
 # Original logo: http://docs.oasis-open.org/templates/OASISLogo-v3.0.png
 title: Attribute-Centric Authorization Language (ACAL) Version 1.0
 subtitle: Committee Specification Draft 02
-keywords: 
-- access control
-- authorization
-- ABAC
-- policy language
-- standard
+version: "1.0"
+stage_revision: csd02 # [stage-abbrev][revisionNumber] as defined in https://docs.oasis-open.org/specGuidelines/ndr/namingDirectives.html
+lang: en
+keywords: ["access", "authorization", "ABAC", "policylanguage", "standard"]
 # date metadata is set automatically to current date, unless specified on pandoc commandline: --metadata date="..."
+
+# If metadata 'x' is a string, any placeholder %x% will be replaced with the value of metadata 'x' (using meta_vars.lua filter), e.g. %version% will be replaced with the version metadata value.
 ---
 
 ### This version
 
-- https://docs.oasis-open.org/xacml/acal/acal/core/v1.0/csd02/acal-core-v1.0-csd02.html (Authoritative)
-- https://docs.oasis-open.org/xacml/acal/acal/core/v1.0/csd02/acal-core-v1.0-csd02.pdf
-- https://docs.oasis-open.org/xacml/acal/acal/core/v1.0/csd02/acal-core-v1.0-csd02.md
+- https://docs.oasis-open.org/xacml/acal/acal/core/v%version%/%stage_revision%/acal-core-v%version%-%stage_revision%.html (Authoritative)
+- https://docs.oasis-open.org/xacml/acal/acal/core/v%version%/%stage_revision%/acal-core-v%version%-%stage_revision%.pdf
+- https://docs.oasis-open.org/xacml/acal/acal/core/v%version%/%stage_revision%/acal-core-v%version%-%stage_revision%.md
 
 ### Previous version
 
@@ -54,7 +54,7 @@ N/A
 
 ### Abstract
 
-This specification defines Version 1.0 of the Attribute-Centric Authorization Language's core model. This model is essentially an XML-agnostic evolution of [XACML v3.0](#xacml) that provides a common foundation for other concrete representation formats to come (e.g. JSON).
+This specification defines Version %version% of the Attribute-Centric Authorization Language's core model. This model is essentially an XML-agnostic evolution of [XACML v3.0](#xacml) that provides a common foundation for other concrete representation formats to come (e.g. JSON).
 
 
 ### Citation Format
@@ -63,7 +63,7 @@ When referencing this document, the following citation format should be used:
 
 **[ACAL-Core-1.0]**
 _%title%_.
-Edited by Steven Legg and Cyril Dangerville. %date% . OASIS %subtitle%. https://docs.oasis-open.org/xacml/acal/acal/core/v1.0/csd02/acal-core-v1.0-csd02.html . Latest version: https://docs.oasis-open.org/xacml/acal/acal/core/v1.0/acal-core-v1.0.html
+Edited by Steven Legg and Cyril Dangerville. %date%. OASIS %subtitle%. https://docs.oasis-open.org/xacml/acal/acal/core/v%version%/%stage_revision%/acal-core-v%version%-%stage_revision%.html . Latest version: https://docs.oasis-open.org/xacml/acal/acal/core/v1.0/acal-core-v1.0.html
 
 
 ### Related Work
@@ -3427,10 +3427,10 @@ hide circle
 abstract class IdReferenceType <<dataType>> {
    + Id: URI [1]
 }
-@enduml
 
 class ExactMatchIdReferenceType <<dataType>> extends IdReferenceType
 class PatternMatchIdReferenceType <<dataType>> extends IdReferenceType
+@enduml
 ```
 
 The `IdReferenceType` object type contains the following property:
@@ -8103,13 +8103,11 @@ HTML/PDF versions are generated automatically online via Github Actions after ea
 
 ### Prerequisites
 
-Install Pandoc, Graphviz and PlantUML on your system; or simply use Docker with the following shell alias:
+Install Pandoc **v3.2.1 or later** ( [latest release](https://github.com/jgm/pandoc/releases/latest) ), Graphviz and PlantUML on your system; or simply use Docker with the following shell alias:
 ```
 $ alias pandoc='docker run --rm --volume "$(pwd):/data" cdang/pandoc-plantuml'
 ```
 _The Dockerfile (named `Dockerfile`) of the docker image used in the alias above is provided in the [pandoc](pandoc) folder next to this markdown file for your convenience if you wish to build it yourself._  
-
-OASIS staff are currently using pandoc 3.0 from https://github.com/jgm/pandoc/releases/tag/3.0.
 
 Git clone or get a local copy of [OASIS XACML TC Github repository](https://github.com/oasis-tcs/xacml-spec/), open a terminal and **change your working directory to the root directory of your local copy of the repository**.
 
@@ -8122,21 +8120,24 @@ The generation command uses a CSS stylesheet file (`-c` argument) provided by OA
 
 ### HTML generation
 
-Run the following command line to generate HTML from this markdown file (named `acal-core-v1.0-csd02.md`) to an output file `/tmp/acal-core-v1.0-csd02.html`:
+Run the following command line to generate the HTML from this markdown file (input file specified as last argument):
 
 ```console
-$ pandoc -f gfm+definition_lists -t html -c styles/markdown-styles-v1.7.3a.css -s --template pandoc/templates/default.html --lua-filter pandoc/diagram.lua --lua-filter pandoc/meta_vars.lua --defaults pandoc/defaults.yaml --embed-resources -o /tmp/acal-core-v1.0-csd02.html acal-core-v1.0-csd02.md
+$ pandoc/mkdocs.sh --output /tmp acal-core-v%version%.md
 ```
+The `--output` option sets the output directory, and the output filename is the same as the input file (last argument) except `.md` extension is replaced with `.html`.
+
+The publication date is automatically set to the current date by default (using Lua filter `pandoc/meta_vars.lua`). However, you may set a specific date of your choice instead, by adding the argument `--metadata date="My date in the form DD Month YYYY"` at the end of the command. 
 
 ### PDF generation
 
-For PDF output (file `/tmp/acal-core-v1.0-csd02.pdf`), the command line is the following (different `-t` and `-H` arguments):
+For PDF output, add the `--pdf` option as follows:
 
 ```console
-$ DATE=$(date -u +"%d %B %Y")
-$ pandoc -f gfm+definition_lists -t pdf -c styles/markdown-styles-v1.7.3a.css -H pandoc/custom_latex_header_for_pandoc_pdf_output.tex -s -L pandoc/diagram.lua --lua-filter pandoc/meta_vars.lua --defaults pandoc/defaults.yaml --embed-resources -o /tmp/acal-core-v1.0-csd02.pdf acal-core-v1.0-csd02.md
+$ pandoc/mkdocs.sh --pdf --output /tmp acal-core-v%version%.md
 ```
 
+The HTML file is generated like the previous command and, in addition, a PDF file is generated with the same name as the input file except the `.md` extension is replaced with `.pdf` in this case.
 
 ---
 
@@ -8295,7 +8296,7 @@ ACAL 1.0 is a successor to XACML 3.0. ACAL 1.0 differs from XACML 3.0 in the fol
 
 ## Revision History
 
-Latest revision history can be obtained from [OASIS XACML TC's github repository](https://github.com/oasis-tcs/xacml-spec/blob/v1.0-csd02/acal-core-v1.0-csd02.md).
+Latest revision history can be obtained from [OASIS XACML TC's github repository](https://github.com/oasis-tcs/xacml-spec/blob/v%version%-%stage_revision%/acal-core-v%version%-%stage_revision%.md).
 
 <!--
 - \< Date in yyyy-mm-dd format \>, \< Revision number \>  

--- a/acal-core-xml-v4.0.md
+++ b/acal-core-xml-v4.0.md
@@ -1,19 +1,25 @@
-![OASIS](http://docs.oasis-open.org/templates/OASISLogo-v3.0.png)
-
 ---
+# Document metadata processed by Pandoc:
+logo: |
+  ![OASIS](images/OASISLogo-v3.0.png)
+# Original logo: http://docs.oasis-open.org/templates/OASISLogo-v3.0.png
+title: eXtensible Access Control Markup Language (XACML) Version 4.0 (XML Representation of ACAL Version 1.0)
+subtitle: Committee Specification Draft 02
+version: "4.0"
+stage_revision: csd02 # [stage-abbrev][revisionNumber] as defined in https://docs.oasis-open.org/specGuidelines/ndr/namingDirectives.html
+lang: en
+keywords: ["access", "authorization", "ABAC", "policylanguage", "XML", "standard"]
+# date metadata is set automatically to current date, unless specified on pandoc commandline: --metadata date="..."
 
-# eXtensible Access Control Markup Language (XACML) Version 4.0 (XML Representation of ACAL Version 1.0)
-
-## Committee Specification Draft 01
-
-## 18 February 2026
+# If metadata 'x' is a string, any placeholder %x% will be replaced with the value of metadata 'x' (using meta_vars.lua filter), e.g. %version% will be replaced with the version metadata value.
+---
 
 ### This version:
 
 
-- https://docs.oasis-open.org/xacml/acal/xacml/core/v4.0/csd01/acal-core-xml-v4.0-csd01.html (Authoritative)
-- https://docs.oasis-open.org/xacml/acal/xacml/core/v4.0/csd01/acal-core-xml-v4.0-csd01.pdf
-- https://docs.oasis-open.org/xacml/acal/xacml/core/v4.0/csd01/acal-core-xml-v4.0-csd01.md
+- https://docs.oasis-open.org/xacml/acal/xacml/core/v%version%/%stage_revision%/acal-core-xml-v%version%/%stage_revision%.html (Authoritative)
+- https://docs.oasis-open.org/xacml/acal/xacml/core/v%version%/%stage_revision%/acal-core-xml-v%version%/%stage_revision%.pdf
+- https://docs.oasis-open.org/xacml/acal/xacml/core/v%version%/%stage_revision%/acal-core-xml-v%version%/%stage_revision%.md
 
 ### Previous version:
 
@@ -23,9 +29,9 @@
 
 ### Latest version:
 
-- https://docs.oasis-open.org/xacml/acal/xacml/core/v4.0/csd01/acal-core-xml-v4.0-csd01.html (Authoritative)
-- https://docs.oasis-open.org/xacml/acal/xacml/core/v4.0/csd01/acal-core-xml-v4.0-csd01.pdf
-- https://docs.oasis-open.org/xacml/acal/xacml/core/v4.0/csd01/acal-core-xml-v4.0-csd01.md
+- https://docs.oasis-open.org/xacml/acal/xacml/core/v4.0/acal-core-xml-v4.0.html (Authoritative)
+- https://docs.oasis-open.org/xacml/acal/xacml/core/v4.0/acal-core-xml-v4.0.pdf
+- https://docs.oasis-open.org/xacml/acal/xacml/core/v4.0/acal-core-xml-v4.0.md
 
 
 ### Technical Committee:
@@ -49,11 +55,11 @@
 
 This document is one component of a Work Product that also includes:
 
-* Core XML schema: [acal-core-xml-v4.0-schema.xsd](acal-core-xml-v4.0-schema.xsd)
-* Core Schematron rules: [acal-core-xml-v4.0-schematron.sch](acal-core-xml-v4.0-schematron.sch)
-* Short identifier set: [acal-core-xml-v4.0-identifiers.xml](acal-core-xml-v4.0-identifiers.xml)
-* XPath Profile XML schema: [acal-xpath-xml-v4.0-schema.xsd](acal-xpath-xml-v4.0-schema.xsd)
-* JSONPath Profile XML schema: [acal-jsonpath-xml-v4.0-schema.xsd](acal-jsonpath-xml-v4.0-schema.xsd)
+* [Core XML schema](acal-core-xml-v%version%-schema.xsd);
+* [Core Schematron rules](acal-core-xml-v%version%-schematron.sch);
+* [Short identifier set](acal-core-xml-v%version%-identifiers.xml);
+* [XPath Profile XML schema](acal-xpath-xml-v%version%-schema.xsd);
+* [JSONPath Profile XML schema](acal-jsonpath-xml-v%version%-schema.xsd).
 
 <!-- Note: Any normative computer language definitions that are part of the Work Product, such as XML instances, schemas and Java(TM) code, including fragments of such, must be (a) well formed and valid, (b) provided in separate plain text files, (c) referenced from the Work Product; and (d) where any definition in these separate files disagrees with the definition found in the specification, the definition in the separate file prevails. Remove this note before submitting for publication.)
 -->
@@ -67,8 +73,8 @@ This specification defines Version 4.0 of the eXtensible Access Control Markup L
 When referencing this specification the following citation format should be used:
 
 **[XACML-Core-4.0]**
-_eXtensible Access Control Markup Language (XACML) Version 4.0_.
-Edited by Steven Legg and Cyril Dangerville. 18 February 2026. OASIS Committee Specification Draft 01. https://docs.oasis-open.org/xacml/acal/xacml/core/v4.0/csd01/acal-core-xml-v4.0-csd01.html. Latest stage: https://docs.oasis-open.org/xacml/acal/xacml/core/v4.0/csd01/acal-core-xml-v4.0-csd01.html.
+_%title%_.
+Edited by Steven Legg and Cyril Dangerville. %date%. OASIS %subtitle%. https://docs.oasis-open.org/xacml/acal/xacml/core/v%version%/%stage_revision%/acal-core-xml-v%version%-%stage_revision%.html. Latest stage: https://docs.oasis-open.org/xacml/acal/xacml/core/v4.0/acal-core-xml-v4.0.html.
 
 ### Related work:
 
@@ -368,7 +374,7 @@ The list of changes from the previous version and any revision history can be fo
 # 5 Syntax (normative, with the exception of the schema fragments)
 
 The next sections describe the rules that SHALL be applied for mapping the [[ACAL-Core-1.0](#acal-core-10)] agnostic model (UML-based) to [XML schema](#XS) definitions for this XML representation (XACML).
-These rules have been applied to produce XACML's core XML schema in [Annex D](#annex-d-xml-schema-normative) (also in the [Core XML schema file](acal-core-xml-v4.0-schema.xsd) accompanying this document) from [[ACAL-Core-1.0](#acal-core-10)] core model.
+These rules have been applied to produce XACML's core XML schema in [Annex D](#annex-d-xml-schema-normative) (also in the [Core XML schema file](acal-core-xml-v%version%-schema.xsd) accompanying this document) from [[ACAL-Core-1.0](#acal-core-10)] core model.
 
 In all XSD definitions from now, the XACML core namespace `urn:oasis:names:tc:xacml:4.0:core:schema` is the default namespace.
 
@@ -1171,15 +1177,13 @@ HTML/PDF versions are generated automatically online via Github Actions after ea
 
 The following tools are required:
 
-- [Pandoc](https://pandoc.org/);
+- [Pandoc](https://pandoc.org/) **v3.2.1 or later** ( [latest release](https://github.com/jgm/pandoc/releases/latest) );
 - [Pandoc-include filter](https://github.com/DCsunset/pandoc-include).
 
 Either install them on your system or, if you have Docker installed already, simply use the following shell alias:
 ```
 $ alias pandoc='docker run --rm --volume "$(pwd):/data" pandoc/extra'
 ```
-
-OASIS staff are currently using pandoc 3.0 from https://github.com/jgm/pandoc/releases/tag/3.0.
 
 Git clone or get a local copy of [OASIS XACML TC code repository](https://github.com/oasis-tcs/xacml-spec/), open a terminal and **change your working directory to the root directory of your local copy of the repository**.
 
@@ -1193,22 +1197,24 @@ The generation command uses a CSS stylesheet file (`-c` argument) provided by OA
 
 ### HTML generation
 
-Run the following command line to generate HTML from this markdown file (named `acal-core-xml-v4.0-csd01.md`) to an output file `/tmp/acal-core-xml-v4.0-csd01.html` :
+Run the following command line to generate the HTML from this markdown file (input file specified as last argument):
 
 ```console
-$ pandoc -s --verbose --embed-resources -f gfm+definition_lists -c styles/markdown-styles-v1.7.3a.css -F pandoc-include -M lang=en -M title=" " -t html -o /tmp/acal-core-xml-v4.0-csd01.html acal-core-xml-v4.0-csd01.md
+$ pandoc/mkdocs.sh --output /tmp acal-core-xml-v%version%.md
 ```
+The `--output` option sets the output directory, and the output filename is the same as the input file (last argument) except `.md` extension is replaced with `.html`.
 
-Note this command generates a document which may require additional editing in order to be published in the expected OASIS style. This editing will be handled by OASIS staff during publication.
+The publication date is automatically set to the current date by default (using Lua filter `pandoc/meta_vars.lua`). However, you may set a specific date of your choice instead, by adding the argument `--metadata date="My date in the form DD Month YYYY"` at the end of the command. 
 
 ### PDF generation
 
-For PDF output, the command line is the following (different `-t` and `-H` arguments, and output goes to file `/tmp/acal-core-xml-v4.0-csd01.pdf`):
+For PDF output, add the `--pdf` option as follows:
 
 ```console
-$ pandoc -s --embed-resources -f gfm+definition_lists -c styles/markdown-styles-v1.7.3a.css -F pandoc-include -H pandoc/custom_latex_header_for_pandoc_pdf_output.tex --metadata title=" " -t pdf -o /tmp/acal-core-xml-v4.0-csd01.pdf acal-core-xml-v4.0-csd01.md
+$ pandoc/mkdocs.sh --pdf --output /tmp acal-core-xml-v%version%.md
 ```
 
+The HTML file is generated like the previous command and, in addition, a PDF file is generated with the same name as the input file except the `.md` extension is replaced with `.pdf` in this case.
 
 
 # Appendix 1. Acknowledgments
@@ -1343,7 +1349,7 @@ XACML 4.0 differs from XACML 3.0 in the following ways:
 
 ## Revision History
 
-Latest revision history can be obtained from [OASIS XACML TC's code repository](https://github.com/oasis-tcs/xacml-spec/blob/v1.0-csd01/acal-core-xml-v4.0-csd01.md).
+Latest revision history can be obtained from [OASIS XACML TC's code repository](https://github.com/oasis-tcs/xacml-spec/blob/v%version%-%stage_revision%/acal-core-xml-v%version%-%stage_revision%.md).
 
 | Revision | Date | Editor | Changes Made |
 | :--- | :--- | :--- | :--- |

--- a/acal-jsonpath-v1.0.md
+++ b/acal-jsonpath-v1.0.md
@@ -1,24 +1,25 @@
-﻿![OASIS](http://docs.oasis-open.org/templates/OASISLogo-v3.0.png)
+﻿---
+# Document metadata processed by Pandoc:
+logo: |
+  ![OASIS](images/OASISLogo-v3.0.png)
+# Original logo: http://docs.oasis-open.org/templates/OASISLogo-v3.0.png
+title: ACAL v1.0 JSONPath Profile Version 1.0
+subtitle: Committee Specification Draft 02
+version: "1.0"
+stage_revision: csd02 # [stage-abbrev][revisionNumber] as defined in https://docs.oasis-open.org/specGuidelines/ndr/namingDirectives.html
+lang: en
+keywords: ["access", "authorization", "ABAC", "policylanguage", "JSON", "JSONPath", "standard"]
+# date metadata is set automatically to current date, unless specified on pandoc commandline: --metadata date="..."
 
-
+# If metadata 'x' is a string, any placeholder %x% will be replaced with the value of metadata 'x' (using meta_vars.lua filter), e.g. %version% will be replaced with the version metadata value.
 ---
-
-
-# ACAL v1.0 JSONPath Profile Version 1.0
-
-
-## Committee Specification Draft 01
-
-
-## 18 February 2026
-
 
 ### This version:
 
 
-- https://docs.oasis-open.org/xacml/acal/acal/profiles/jsonpath/v1.0/csd01/acal-jsonpath-v1.0-csd01.html (Authoritative)
-- https://docs.oasis-open.org/xacml/acal/acal/profiles/jsonpath/v1.0/csd01/acal-jsonpath-v1.0-csd01.pdf
-- https://docs.oasis-open.org/xacml/acal/acal/profiles/jsonpath/v1.0/csd01/acal-jsonpath-v1.0-csd01.md
+- https://docs.oasis-open.org/xacml/acal/acal/profiles/jsonpath/v%version%/%stage_revision%/acal-jsonpath-v%version%-%stage_revision%.html (Authoritative)
+- https://docs.oasis-open.org/xacml/acal/acal/profiles/jsonpath/%version%/%stage_revision%/acal-jsonpath-v%version%-%stage_revision%.pdf
+- https://docs.oasis-open.org/xacml/acal/acal/profiles/jsonpath/v%version%/%stage_revision%/acal-jsonpath-v%version%-%stage_revision%.md
 
 ### Previous version:
 
@@ -26,9 +27,9 @@ N/A
 
 ### Latest version:
 
-- https://docs.oasis-open.org/xacml/acal/acal/profiles/jsonpath/v1.0/csd01/acal-jsonpath-v1.0-csd01.html (Authoritative)
-- https://docs.oasis-open.org/xacml/acal/acal/profiles/jsonpath/v1.0/csd01/acal-jsonpath-v1.0-csd01.pdf
-- https://docs.oasis-open.org/xacml/acal/acal/profiles/jsonpath/v1.0/csd01/acal-jsonpath-v1.0-csd01.md
+- https://docs.oasis-open.org/xacml/acal/acal/profiles/jsonpath/v1.0/acal-jsonpath-v1.0.html (Authoritative)
+- https://docs.oasis-open.org/xacml/acal/acal/profiles/jsonpath/v1.0/acal-jsonpath-v1.0.pdf
+- https://docs.oasis-open.org/xacml/acal/acal/profiles/jsonpath/v1.0/acal-jsonpath-v1.0.md
 
 
 ### Technical Committee
@@ -67,8 +68,8 @@ This specification is a profile of ACAL that provides ACAL extensions based on t
 When referencing this document, the following citation format should be used:
 
 **[ACAL-JSONPath-1.0]**
-_ACAL v1.0 JSONPath Profile Version 1.0_.
-Edited by Steven Legg and Cyril Dangerville. 18 February 2026. OASIS Committee Specification Draft 01. https://docs.oasis-open.org/xacml/acal/acal/profiles/jsonpath/v1.0/csd01/acal-jsonpath-v1.0-csd01.html. Latest stage: https://docs.oasis-open.org/xacml/acal/acal/profiles/jsonpath/v1.0/csd01/acal-jsonpath-v1.0-csd01.html.
+_%title%_.
+Edited by Steven Legg and Cyril Dangerville. %date%. OASIS %subtitle%. https://docs.oasis-open.org/xacml/acal/acal/profiles/jsonpath/v%version%/%stage_revision%/acal-jsonpath-v%version%-%stage_revision%.html. Latest stage: https://docs.oasis-open.org/xacml/acal/acal/profiles/jsonpath/v1.0/acal-jsonpath-v1.0.html.
 
 
 ### Related Work
@@ -731,13 +732,11 @@ HTML/PDF versions are generated automatically online via Github Actions after ea
 
 ### Prerequisites
 
-Install Pandoc, Graphviz and PlantUML on your system; or simply use Docker with the following shell alias:
+Install Pandoc **v3.2.1 or later** ( [latest release](https://github.com/jgm/pandoc/releases/latest) ), Graphviz and PlantUML on your system; or simply use Docker with the following shell alias:
 ```
 $ alias pandoc='docker run --rm --volume "$(pwd):/data" cdang/pandoc-plantuml'
 ```
-_The Dockerfile (named `Dockerfile`) of the docker image used in the alias above is provided in the [pandoc](pandoc) folder next to this markdown file for your convenience if you wish to build it yourself._  
-
-OASIS staff are currently using pandoc 3.0 from https://github.com/jgm/pandoc/releases/tag/3.0.
+_The Dockerfile (named `Dockerfile`) of the docker image used in the alias above is provided in the [pandoc](pandoc) folder next to this markdown file for your convenience if you wish to build it yourself._ 
 
 Git clone or get a local copy of [OASIS XACML TC Github repository](https://github.com/oasis-tcs/xacml-spec/), open a terminal and **change your working directory to the root directory of your local copy of the repository**.
 
@@ -749,21 +748,25 @@ The generation command uses a CSS stylesheet file (`-c` argument) provided by OA
 
 ### HTML generation
 
-Run the following command line to generate HTML from this markdown file (`acal-jsonpath-v1.0-csd01.md`) to an output file `/tmp/acal-jsonpath-v1.0-csd01.html`:
+Run the following command line to generate the HTML from this markdown file (input file specified as last argument):
 
 ```console
-$ pandoc -f gfm+definition_lists -t html -c styles/markdown-styles-v1.7.3a.css -s --lua-filter pandoc/diagram.lua --defaults pandoc/defaults.yaml --embed-resources --metadata title=" " -o /tmp/acal-jsonpath-v1.0-csd01.html acal-jsonpath-v1.0-csd01.md 
+$ pandoc/mkdocs.sh --output /tmp acal-jsonpath-v%version%.md
 ```
+The `--output` option sets the output directory, and the output filename is the same as the input file (last argument) except `.md` extension is replaced with `.html`.
 
-Note this command generates a Table of Contents (TOC) in HTML which is located at the top of the HTML document, and which requires additional editing in order to be published in the expected OASIS style. This editing will be handled by OASIS staff during publication.
+The publication date is automatically set to the current date by default (using Lua filter `pandoc/meta_vars.lua`). However, you may set a specific date of your choice instead, by adding the argument `--metadata date="My date in the form DD Month YYYY"` at the end of the command. 
 
 ### PDF generation
 
-For PDF output (file `/tmp/acal-jsonpath-v1.0-csd01.pdf`), the command line is the following (different `-t` and `-H` arguments):
+For PDF output, add the `--pdf` option as follows:
 
 ```console
-$ pandoc -f gfm+definition_lists -t pdf -c styles/markdown-styles-v1.7.3a.css -H pandoc/custom_latex_header_for_pandoc_pdf_output.tex -s -L pandoc/diagram.lua --defaults pandoc/defaults.yaml --metadata title=" " --embed-resources -o /tmp/acal-jsonpath-v1.0-csd01.pdf acal-jsonpath-v1.0-csd01.md 
+$ pandoc/mkdocs.sh --pdf --output /tmp acal-jsonpath-v%version%.md
 ```
+
+The HTML file is generated like the previous command and, in addition, a PDF file is generated with the same name as the input file except the `.md` extension is replaced with `.pdf` in this case.
+
 
 # Appendix 1 Acknowledgments
 
@@ -851,7 +854,7 @@ This is the first version of this profile.
 
 ## Revision History
 
-Latest revision history can be obtained from [OASIS XACML TC's github repository](https://github.com/oasis-tcs/xacml-spec/blob/v1.0-csd01/acal-jsonpath-v1.0-csd01.md).
+Latest revision history can be obtained from [OASIS XACML TC's github repository](https://github.com/oasis-tcs/xacml-spec/blob/v%version%-%stage_revision%/acal-jsonpath-v%version%-%stage_revision%.md).
 
 <!--
 - \< Date in yyyy-mm-dd format \>, \< Revision number \>  

--- a/acal-xpath-v1.0.md
+++ b/acal-xpath-v1.0.md
@@ -1,23 +1,24 @@
-﻿![OASIS](http://docs.oasis-open.org/templates/OASISLogo-v3.0.png)
+﻿---
+# Document metadata processed by Pandoc:
+logo: |
+  ![OASIS](images/OASISLogo-v3.0.png)
+# Original logo: http://docs.oasis-open.org/templates/OASISLogo-v3.0.png
+title: ACAL v1.0 XPath Profile Version 1.0
+subtitle: Committee Specification Draft 02
+version: "1.0"
+stage_revision: csd02 # [stage-abbrev][revisionNumber] as defined in https://docs.oasis-open.org/specGuidelines/ndr/namingDirectives.html
+lang: en
+keywords: ["access", "authorization", "ABAC", "policylanguage", "XML", "XPath", "standard"]
+# date metadata is set automatically to current date, unless specified on pandoc commandline: --metadata date="..."
 
-
+# If metadata 'x' is a string, any placeholder %x% will be replaced with the value of metadata 'x' (using meta_vars.lua filter), e.g. %version% will be replaced with the version metadata value.
 ---
-
-
-# ACAL v1.0 XPath Profile Version 1.0
-
-
-## Committee Specification Draft 01
-
-
-## 18 February 2026
-
 
 ### This version
 
-- https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v1.0/csd01/acal-xpath-v1.0-csd01.html (Authoritative)
-- https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v1.0/csd01/acal-xpath-v1.0-csd01.pdf
-- https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v1.0/csd01/acal-xpath-v1.0-csd01.md
+- https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v%version%/%stage_revision%/acal-xpath-v%version%-%stage_revision%.html (Authoritative)
+- https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v%version%/%stage_revision%/acal-xpath-v%version%-%stage_revision%.pdf
+- https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v%version%/%stage_revision%/acal-xpath-v%version%-%stage_revision%.md
 
 
 ### Previous version
@@ -28,9 +29,9 @@ N/A
 ### Latest version
 
 
-- https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v1.0/csd01/acal-xpath-v1.0-csd01.html (Authoritative)
-- https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v1.0/csd01/acal-xpath-v1.0-csd01.pdf
-- https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v1.0/csd01/acal-xpath-v1.0-csd01.md
+- https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v1.0/acal-xpath-v1.0.html (Authoritative)
+- https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v1.0/acal-xpath-v1.0.pdf
+- https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v1.0/acal-xpath-v1.0.md
 
 
 ### Technical Committee
@@ -69,8 +70,8 @@ This specification is a profile of ACAL that provides ACAL extensions based on t
 When referencing this document, the following citation format should be used:
 
 **[ACAL-XPath-1.0]**
-_ACAL v1.0 XPath Profile Version 1.0_.
-Edited by Steven Legg and Cyril Dangerville. 18 February 2026. OASIS Committee Specification Draft 01. https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v1.0/csd01/acal-xpath-v1.0-csd01.html . Latest stage: https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v1.0/csd01/acal-xpath-v1.0-csd01.html .
+_%title%_.
+Edited by Steven Legg and Cyril Dangerville. %date%. OASIS %subtitle%. https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v%version%/%stage_revision%/acal-xpath-v%version%-%stage_revision%.html . Latest stage: https://docs.oasis-open.org/xacml/acal/acal/profiles/xpath/v1.0/acal-xpath-v1.0.html .
 
 
 ### Related Work
@@ -1190,7 +1191,7 @@ HTML/PDF versions are generated automatically online via Github Actions after ea
 
 The following tools are required:
 
-- [Pandoc](https://pandoc.org/);
+- [Pandoc](https://pandoc.org/) **v3.2.1 or later** ( [latest release](https://github.com/jgm/pandoc/releases/latest) );
 - [Pandoc-include filter](https://github.com/DCsunset/pandoc-include).
 - [PlantUML](https://plantuml.com/starting)
 
@@ -1202,8 +1203,6 @@ $ alias pandoc='docker run --rm --volume "$(pwd):/data" cdang/pandoc-plantuml'
 ```
 _The Dockerfile (named `Dockerfile`) of the docker image used in the alias above is provided in the [pandoc](pandoc) folder next to this markdown file for your convenience if you wish to build it yourself._  
 
-OASIS staff are currently using pandoc 3.0 from https://github.com/jgm/pandoc/releases/tag/3.0.
-
 Git clone or get a local copy of [OASIS XACML TC Github repository](https://github.com/oasis-tcs/xacml-spec/), open a terminal and **change your working directory to the root directory of your local copy of the repository**.
 
 ### CSS stylesheet
@@ -1214,23 +1213,25 @@ The generation command uses a CSS stylesheet file (`-c` argument) provided by OA
 
 ### HTML generation
 
-Run the following command line to generate HTML from this markdown file (`acal-xpath-v1.0-csd01.md`) to an output file `/tmp/acal-xpath-v1.0-csd01.html`:
+Run the following command line to generate the HTML from this markdown file (input file specified as last argument):
 
-<!-- fenced_code_attributes pandoc extension is used for numberine lines in code blocks; fenced_code_attributes is not supported for 'gfm' format. Using 'markdown' instead. -->
 ```console
-$ pandoc -f markdown+definition_lists+fenced_code_attributes -c styles/markdown-styles-v1.7.3a.css --standalone --filter pandoc-include --lua-filter pandoc/diagram.lua --defaults pandoc/defaults.yaml --embed-resources --metadata title=" " -t html -o /tmp/acal-xpath-v1.0-csd01.html acal-xpath-v1.0-csd01.md
+$ pandoc/mkdocs.sh --number-lines --output /tmp acal-xpath-v%version%.md
 ```
+The `--output` option sets the output directory, and the output filename is the same as the input file (last argument) except `.md` extension is replaced with `.html`.
 
-Note this command generates a Table of Contents (TOC) in HTML which is located at the top of the HTML document, and which requires additional editing in order to be published in the expected OASIS style. This editing will be handled by OASIS staff during publication.
+The publication date is automatically set to the current date by default (using Lua filter `pandoc/meta_vars.lua`). However, you may set a specific date of your choice instead, by adding the argument `--metadata date="My date in the form DD Month YYYY"` at the end of the command. 
 
 ### PDF generation
 
-For PDF output (file `/tmp/acal-xpath-v1.0-csd01.pdf`), the command line is the following (different `-t` and `-H` arguments):
+For PDF output, add the `--pdf` option as follows:
 
-<!-- fenced_code_attributes pandoc extension is used for numberine lines in code blocks; fenced_code_attributes is not supported for 'gfm' format. Using 'markdown' instead. -->
 ```console
-$ pandoc -f markdown+definition_lists+fenced_code_attributes -c styles/markdown-styles-v1.7.3a.css -H pandoc/custom_latex_header_for_pandoc_pdf_output.tex --standalone --filter pandoc-include --lua-filter pandoc/diagram.lua --defaults pandoc/defaults.yaml --embed-resources --metadata title=" " -t pdf -o /tmp/acal-xpath-v1.0-csd01.pdf acal-xpath-v1.0-csd01.md
+$ pandoc/mkdocs.sh --number-lines --pdf --output /tmp acal-xpath-v%version%.md
 ```
+
+The HTML file is generated like the previous command and, in addition, a PDF file is generated with the same name as the input file except the `.md` extension is replaced with `.pdf` in this case.
+
 
 # Appendix 1 Acknowledgments
 
@@ -1331,14 +1332,12 @@ This ACAL Profile is a successor to the set of XPath-based features of XACML 3.0
 
 ## Revision History
 
-Latest revision history can be obtained from [OASIS XACML TC's code repository](https://github.com/oasis-tcs/xacml-spec/blob/v1.0-csd01/acal-xpath-v1.0-csd01.md).
+Latest revision history can be obtained from [OASIS XACML TC's code repository](https://github.com/oasis-tcs/xacml-spec/blob/v%version%-%stage_revision%/acal-xpath-v%version%-%stage_revision%.md).
 
 <!--
 - \< Date in yyyy-mm-dd format \>, \< Revision number \>  
 - \< Date in yyyy-mm-dd format \>, \< Revision number \>
 -->
-
----
 
 <!--
 # Appendix 3 OASIS Open Specification Template Instructions

--- a/old/custom_latex_header_for_pandoc_pdf_output.tex
+++ b/old/custom_latex_header_for_pandoc_pdf_output.tex
@@ -1,3 +1,7 @@
+% Workaround for https://github.com/jgm/pandoc/issues/11528
+\usepackage{hyperref}
+\usepackage{hyperxmp}
+
 % Fix to add line breaks in definition lists for PDF output and to overcome "Too deeply nested" error
 \usepackage{enumitem}
 \setlist[description]{style=nextline}
@@ -37,12 +41,14 @@
 
 % Place OASIS logo before the document title block
 \usepackage{graphicx}
-\let\oldmaketitle\maketitle
-\renewcommand{\maketitle}{%
-  \begin{center}%
-    \includegraphics[width=0.35\linewidth]{images/OASISLogo-v3.0.png}%
-  \end{center}%
-  \vspace{0.5cm}%
-  \oldmaketitle%
-}
+%\pretocmd{\@title}{\includegraphics[width=0.35]{images/OASISLogo-v3.0.png}}{}{}
+%\renewcommand\title{\includegraphics[width=0.35\linewidth]{images/OASISLogo-v3.0.png}$title$}
+%\let\oldmaketitle\maketitle
+%\renewcommand{\maketitle}{%
+%  \begin{center}%
+%    \includegraphics[width=0.35\linewidth]{images/OASISLogo-v3.0.png}%
+%  \end{center}%
+%  \vspace{0.5cm}%
+%  \oldmaketitle%
+%}
 

--- a/pandoc/draft/.gitignore
+++ b/pandoc/draft/.gitignore
@@ -1,3 +1,0 @@
-# Ignore all draft output files — this directory is tracked but its contents are not.
-*
-!.gitignore

--- a/pandoc/meta_vars.lua
+++ b/pandoc/meta_vars.lua
@@ -1,3 +1,10 @@
+-- Replace $(x) where 'x' is one of the metadata (${x} and {{x}} don't work in URLs, handled as delimiter by Pandoc)
+local PLACEHOLDER_START = "%"
+local PLACEHOLDER_END = "%"
+local PLACEHOLDER_START_LEN = string.len(PLACEHOLDER_START)
+local PLACEHOLDER_END_LEN = string.len(PLACEHOLDER_END)
+local MIN_PLACEHOLDER_LEN_EXCLUDING_FIRST_CHAR = PLACEHOLDER_START_LEN + PLACEHOLDER_END_LEN
+
 local vars = {}
 
 -- Set date metadata to current date if unset. Based on https://pandoc.org/lua-filters.html#setting-the-date-in-the-metadata
@@ -6,8 +13,12 @@ function Meta(m)
     m.date = os.date("%d %B %Y")
   end
   for k, v in pairs(m) do
-    print("key:"..k..",value:"..tostring(v))
-    vars["%" .. k .. "%"] = v -- {table.unpack(v)}
+    -- print("k: ".. k .. ", v: ".. vars[k])
+    if pandoc.utils.type(v) == 'Inlines' then
+      vars[k] = pandoc.utils.stringify(v)
+    elseif pandoc.utils.type(v) == 'string' then
+      vars[k] = v
+    end
   end
   return m
 end
@@ -17,19 +28,89 @@ end
 -- local function get_vars (meta)
 --  for k, v in pairs(meta) do
 --    print("key:"..k..",value:"..tostring(v))
---    vars["%" .. k .. "%"] = {table.unpack(v)}
+--    vars["${" .. k .. "}"] = {table.unpack(v)}
 --  end
 -- end
 
-local function replace (el)
-  if vars[el.text] then
-    return pandoc.Span(vars[el.text])
-  else
-    return el
+local function replace (str)
+  -- print("Replacing String: "..el.text)
+  -- Simple form but requires to have whitespaces before/after the placeholder:
+  -- if vars[str] then
+  --   return pandoc.Span(vars[str])
+  -- else
+  --   return el
+  -- end
+
+  -- Advanced form: placeholder can be replaced anywhere:
+  local search_init_index = 1
+  local replacement_parts = {}
+  local last_placeholder_end_last_index = 0
+  while(search_init_index + MIN_PLACEHOLDER_LEN_EXCLUDING_FIRST_CHAR <= string.len(str))
+  do
+    local placeholder_start_first_index, placeholder_start_last_index = string.find(str, PLACEHOLDER_START, search_init_index, true)
+    if placeholder_start_first_index then
+      local placeholder_end_first_index, placeholder_end_last_index = string.find(str, PLACEHOLDER_END, placeholder_start_last_index + 1, true)
+      if placeholder_end_first_index then 
+        local key = string.sub(str, placeholder_start_last_index + 1, placeholder_end_first_index-1)
+        if vars[key] then
+          if last_placeholder_end_last_index+1 < placeholder_start_first_index then
+            -- Append the substring between the last placeholder and this one, as is, if there is any
+            table.insert(replacement_parts, string.sub(str, last_placeholder_end_last_index+1, placeholder_start_first_index-1) )
+          end
+          -- Replace the placeholder with the corresponding metadata value
+          table.insert(replacement_parts, vars[key])
+          last_placeholder_end_last_index = placeholder_end_last_index
+        end
+        search_init_index = placeholder_end_last_index + 1
+      else
+        -- No PLACEHOLDER_END found after PLACEHOLDER_START, resume the search after PLACEHOLDER_START
+        search_init_index = placeholder_start_last_index + 1
+      end
+    else
+      -- No placeholder found
+      break
+    end
+    
   end
+
+  if last_placeholder_end_last_index == 0 then
+    -- No placeholder found, nothing to replace
+    return nil
+  else
+    -- Append the substring between the last placeholder and the end, as is, if there is any
+    if last_placeholder_end_last_index < string.len(str) then table.insert(replacement_parts, string.sub(str, last_placeholder_end_last_index+1 )) end
+    local replacement = table.concat(replacement_parts)
+    return replacement
+  end
+
+end
+
+local function replace_Str(el)
+  -- print("Replacing ".. pandoc.utils.type(el)..": "..tostring(el))
+  -- if el.text then
+  local replacement = replace(el.text)
+  if replacement then el.text = replacement end
+  return el
+  --end
+end
+
+-- TODO: remove if unncessary
+local function replace_Link_target(el)
+  -- print("Replacing Link target: "..el.target)
+  local replacement = replace(el.target)
+  if replacement then el.target = replacement end
+  return el
+end
+
+local function replace_CodeBlock(el)
+  -- print("Replacing ".. pandoc.utils.type(el)..": "..tostring(el))
+  local replacement = replace(el.text)
+  if replacement then el.text = replacement end
+  return el
 end
 
 function Pandoc(doc)
-  print("Publication date changed to '"..vars["%date%"].."'. Remember to update the date also in References from other documents to this one.")
-  return doc:walk { Meta = get_vars }:walk { Str = replace }
+  print("Publication date changed to '"..vars["date"].."'. If this is official, remember to update the date also in References from other documents to this one.")
+  local doc_after_meta_vars_replaced =  doc:walk { Meta = get_vars }:walk { Str = replace_Str, Link = replace_Link_target, CodeBlock = replace_CodeBlock }
+  return pandoc.utils.run_lua_filter(doc_after_meta_vars_replaced, "pandoc/diagram.lua")
 end

--- a/pandoc/mkdocs.sh
+++ b/pandoc/mkdocs.sh
@@ -1,29 +1,39 @@
 #! /bin/bash
 
 usage() {
-    echo "Usage: $(basename "$0") [--pdf] <input.md>"
+    echo "Usage: $(basename "$0") [--number-lines] [--pdf] [--output dir] <input.md> [extra pandoc arguments]"
     echo ""
     echo "  Generates an HTML document from the given markdown file."
+    echo "  --number-lines   Number lines in code blocks."
     echo "  --pdf   Also produce a PDF via Chrome headless (requires Chrome)."
     echo "          PDF is generated from the HTML output, not directly from markdown."
+    echo "  --output dir: output directory (path). By default, it is the same directory as the input."
     exit 1
 }
 
 # --- parse arguments ---
+NUMBER_LINES_IN_CODE_BLOCKS=false
 MAKE_PDF=false
+OUTPUT_DIR=""
+SET_OUTPUT_DIR=false
 POSITIONAL=()
 for arg in "$@"; do
     case "$arg" in
-        --pdf) MAKE_PDF=true ;;
         --help|-h) usage ;;
-        *) POSITIONAL+=("$arg") ;;
+        --number-lines) NUMBER_LINES_IN_CODE_BLOCKS=true;;
+        --pdf) MAKE_PDF=true ;;
+        --output) SET_OUTPUT_DIR=true;;
+        *) if $SET_OUTPUT_DIR; then OUTPUT_DIR="$arg"; SET_OUTPUT_DIR=false; else POSITIONAL+=("$arg"); fi;;
     esac
 done
+
 set -- "${POSITIONAL[@]}"
 [ $# -lt 1 ] && usage
 
 INPUT="$1"
 [ ! -f "$INPUT" ] && echo "Error: input file '$INPUT' not found." && exit 1
+
+EXTRA_PANDOC_ARGS=("${POSITIONAL[@]:1}")
 
 # Script's directory — filters, templates, defaults, and draft output live here
 # NOTE: must be resolved before OUTPUT_HTML/OUTPUT_PDF which reference it
@@ -33,8 +43,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INPUT_ABS="$(cd "$(dirname "$INPUT")" && pwd)/$(basename "$INPUT")"
 INPUT_DIR="$(dirname "$INPUT_ABS")"
 BASENAME="$(basename "$INPUT_ABS" .md)"
-OUTPUT_HTML="$SCRIPT_DIR/draft/${BASENAME}.html"
-OUTPUT_PDF="$SCRIPT_DIR/draft/${BASENAME}.pdf"
+OUTPUT_DIR=${OUTPUT_DIR:-${INPUT_DIR}}
+OUTPUT_HTML="${OUTPUT_DIR}/${BASENAME}.html"
+OUTPUT_PDF="${OUTPUT_DIR}/${BASENAME}.pdf"
 
 # --- locate Chrome (macOS app bundles and WSL/Git Bash Windows paths) ---
 # TODO: remove find_chrome() and the --pdf flag once pandoc PDF generation
@@ -116,15 +127,20 @@ fi
 # --- run pandoc from the input file's directory so CSS and image paths resolve ---
 cd "$INPUT_DIR"
 
-$PANDOC -f gfm+definition_lists -t html \
+INPUT_FORMAT="gfm+definition_lists"
+if $NUMBER_LINES_IN_CODE_BLOCKS; then
+    INPUT_FORMAT="markdown+definition_lists+fenced_code_attributes"
+fi
+
+$PANDOC -f "$INPUT_FORMAT" -t html \
   -c styles/markdown-styles-v1.7.3a.css \
   -s \
   --template "$SCRIPT_DIR/templates/default.html" \
-  --lua-filter "$SCRIPT_DIR/diagram.lua" \
+  --filter pandoc-include \
   --lua-filter "$SCRIPT_DIR/meta_vars.lua" \
   --defaults "$SCRIPT_DIR/defaults.yaml" \
   --embed-resources \
-  "${GIT_META[@]}" \
+  "${GIT_META[@]}" "${EXTRA_PANDOC_ARGS[@]}" \
   -o "$OUTPUT_HTML" \
   "$INPUT_ABS"
 
@@ -144,8 +160,7 @@ if $MAKE_PDF; then
       --no-sandbox \
       --no-pdf-header-footer \
       --print-to-pdf="$OUTPUT_PDF" \
-      "file://${OUTPUT_HTML}" \
-      2>/dev/null
+      "file://${OUTPUT_HTML}"
     if [ -f "$OUTPUT_PDF" ]; then
         printf "done\n"
         printf "PDF:  %s\n" "$OUTPUT_PDF"


### PR DESCRIPTION
*Changes initiated by @humantypo*

- mkdocs.sh: new build script accepting input file as CLI parameter; derives output name from input basename; uses SCRIPT_DIR for filter and template paths so it can be called from any working directory; embeds git revision (short hash, branch, commit date) as HTML meta tag and subtle footer; non-fatal if run outside a git repo
 
- pandoc/templates/default.html: add --template-activatable logo guard ($if(logo)$); add $if(git-revision)$ meta tag in <head> and muted footer line; fixes title-before-logo regression caused by missing --template flag in build command

- pandoc/custom_latex_header_for_pandoc_pdf_output.tex: add \renewcommand{\maketitle} to prepend OASIS logo before title block in PDF output, mirroring the HTML template ordering

- acal-core-v1.0.md (Annex F): add --template pandoc/templates/default.html to HTML build command

@cdanger : 
- Improving meta_vars.lua filter to enable substitution of `%my_metadata_var%` with the metadata value anywhere in the doc