### PR TITLE
PolicyPatternMatchReference removal and YACAL/ACAL alignment audit fixes

### DIFF
--- a/acal-core-xml-v4.0-schema.xsd
+++ b/acal-core-xml-v4.0-schema.xsd
@@ -533,11 +533,11 @@ which is to be used in Results (no Content or IncludeInResult attributes).
 		</xs:restriction>
 	</xs:simpleType>
 
-	<!-- Change to XACML 3.0 - Issue #16: old PolicyIdReference Type changed to new
-	PatternMatchIdReferenceType and element name renamed to PolicyPatternMatchReference,
-	which is used only in a SAML XACMLPolicyQuery of the SAML Profile of XACML.
+	<!-- Change to XACML 3.0 - Issue #16: old PolicyIdReferenceType changed to new
+	PatternMatchIdReferenceType, retained here as the base type of PolicyReferenceType.
+	No element of this type is defined in this schema; the SAML Profile of XACML defines
+	one for use in a SAML XACMLPolicyQuery.
 	 See new PolicyReference element below for policy references used in Policies -->
-	<xs:element name="PolicyPatternMatchReference" type="xacml:PatternMatchIdReferenceType" />
 	<!-- Change to XACML 3.0 - Issue #16: New IdReferenceType extension with Version pattern
 	matching, to be used in Policies (PolicyReference) and XACMLPolicyQuery (PolicyIdReference).
 	Same as old PolicyIdReferenceType except the Id is now an XML attribute, cf. IdReferenceType change

--- a/acal-core-yaml-v1.0-constraints.yaml
+++ b/acal-core-yaml-v1.0-constraints.yaml
@@ -513,6 +513,23 @@ Rule:
       YACALSection: "5.9.1"
       ACALSection: "7.12"
 
+  - Id: "noticeexpression-attributeassignmentexpression-unique"
+    Kind: uniqueByProperty
+    Severity: error
+    AppliesTo:
+      ObjectType: NoticeExpressionType
+      CollectionPath: "$..NoticeExpression[].AttributeAssignmentExpression"
+    KeyProperties:
+      - AttributeId
+      - Category
+    Requirement: >
+      AttributeAssignmentExpression values within a NoticeExpressionType
+      MUST be unique by the (AttributeId, Category) pair. An absent
+      Category participates in the pair as an absent value.
+    Provenance:
+      YACALSection: "5.9.1"
+      ACALSection: "7.29"
+
   - Id: "result-notice-id-unique"
     Kind: uniqueByProperty
     Severity: error

--- a/acal-core-yaml-v1.0-constraints.yaml
+++ b/acal-core-yaml-v1.0-constraints.yaml
@@ -511,7 +511,7 @@ Rule:
       NoticeExpression Id values within a RuleType MUST be unique.
     Provenance:
       YACALSection: "5.9.1"
-      ACALSection: "7.17"
+      ACALSection: "7.12"
 
   - Id: "result-notice-id-unique"
     Kind: uniqueByProperty
@@ -525,7 +525,7 @@ Rule:
       Notice Id values within a ResultType MUST be unique.
     Provenance:
       YACALSection: "5.9.3"
-      ACALSection: "7.41"
+      ACALSection: "7.37"
 
   - Id: "result-resultentity-category-unique"
     Kind: uniqueByProperty
@@ -539,7 +539,7 @@ Rule:
       ResultEntity Category values within a ResultType MUST be unique.
     Provenance:
       YACALSection: "5.8.9"
-      ACALSection: "7.41"
+      ACALSection: "7.37"
 
   - Id: "result-applicablepolicyreference-id-unique"
     Kind: uniqueByProperty
@@ -554,7 +554,7 @@ Rule:
       unique.
     Provenance:
       YACALSection: "5.8.10"
-      ACALSection: "7.41"
+      ACALSection: "7.37"
 
   - Id: "bundle-shortidset-id-unique"
     Kind: uniqueByProperty
@@ -612,4 +612,4 @@ Rule:
       unique.
     Provenance:
       YACALSection: "5.8.9"
-      ACALSection: "7.42"
+      ACALSection: "7.45"

--- a/acal-core-yaml-v1.0-structure.schema.yaml
+++ b/acal-core-yaml-v1.0-structure.schema.yaml
@@ -356,7 +356,7 @@ $defs:
       Shared base shape for concrete selector subtypes. The core schema does
       not enable any concrete selector subtype by default.
 
-  AttributeSelectorCoreType:
+  AttributeSelectorType:
     allOf:
       - $ref: "#/$defs/BaseAttributeSelectorType"
       - type: object
@@ -365,15 +365,6 @@ $defs:
         properties:
           Category:
             $ref: "#/$defs/IdentifierType"
-    $comment: >
-      Open (extensible) shape of AttributeSelectorType, used as the base of
-      concrete profile-defined selector subtypes (e.g. the XPath and JSONPath
-      Profile artifacts).
-
-  AttributeSelectorType:
-    allOf:
-      - $ref: "#/$defs/AttributeSelectorCoreType"
-    unevaluatedProperties: false
 
   AttributeSelectorTypeTree:
     type: object
@@ -392,7 +383,7 @@ $defs:
       dynamic anchor to add concrete selector types.
     not: true
 
-  EntityAttributeSelectorCoreType:
+  EntityAttributeSelectorType:
     allOf:
       - $ref: "#/$defs/BaseAttributeSelectorType"
       - type: object
@@ -401,15 +392,6 @@ $defs:
         properties:
           Expression:
             $ref: "#/$defs/ExpressionTypeTree"
-    $comment: >
-      Open (extensible) shape of EntityAttributeSelectorType, used as the base
-      of concrete profile-defined selector subtypes (e.g. the XPath and
-      JSONPath Profile artifacts).
-
-  EntityAttributeSelectorType:
-    allOf:
-      - $ref: "#/$defs/EntityAttributeSelectorCoreType"
-    unevaluatedProperties: false
 
   EntityAttributeSelectorTypeTree:
     type: object

--- a/acal-core-yaml-v1.0-structure.schema.yaml
+++ b/acal-core-yaml-v1.0-structure.schema.yaml
@@ -721,7 +721,10 @@ $defs:
       PolicyIssuer:
         $ref: "#/$defs/EntityType"
       PolicyDefaults:
-        $ref: "#/$defs/PolicyDefaultsTypeTree"
+        type: array
+        minItems: 1
+        items:
+          $ref: "#/$defs/PolicyDefaultsTypeTree"
       Parameter:
         type: array
         minItems: 1
@@ -890,7 +893,10 @@ $defs:
       ShortIdSetReference:
         $ref: "#/$defs/UriArray"
       RequestDefaults:
-        $ref: "#/$defs/RequestDefaultsTypeTree"
+        type: array
+        minItems: 1
+        items:
+          $ref: "#/$defs/RequestDefaultsTypeTree"
       RequestEntity:
         type: array
         items:

--- a/acal-core-yaml-v1.0-structure.schema.yaml
+++ b/acal-core-yaml-v1.0-structure.schema.yaml
@@ -356,7 +356,7 @@ $defs:
       Shared base shape for concrete selector subtypes. The core schema does
       not enable any concrete selector subtype by default.
 
-  AttributeSelectorType:
+  AttributeSelectorCoreType:
     allOf:
       - $ref: "#/$defs/BaseAttributeSelectorType"
       - type: object
@@ -365,10 +365,24 @@ $defs:
         properties:
           Category:
             $ref: "#/$defs/IdentifierType"
+    $comment: >
+      Open (extensible) shape of AttributeSelectorType, used as the base of
+      concrete profile-defined selector subtypes (e.g. the XPath and JSONPath
+      Profile artifacts).
+
+  AttributeSelectorType:
+    allOf:
+      - $ref: "#/$defs/AttributeSelectorCoreType"
     unevaluatedProperties: false
 
   AttributeSelectorTypeTree:
-    $dynamicRef: "#AttributeSelectorTypeExtensions"
+    type: object
+    required:
+      - AttributeSelector
+    properties:
+      AttributeSelector:
+        $dynamicRef: "#AttributeSelectorTypeExtensions"
+    additionalProperties: false
 
   AttributeSelectorTypeExtensionsDisabled:
     $dynamicAnchor: "AttributeSelectorTypeExtensions"
@@ -378,7 +392,7 @@ $defs:
       dynamic anchor to add concrete selector types.
     not: true
 
-  EntityAttributeSelectorType:
+  EntityAttributeSelectorCoreType:
     allOf:
       - $ref: "#/$defs/BaseAttributeSelectorType"
       - type: object
@@ -387,10 +401,24 @@ $defs:
         properties:
           Expression:
             $ref: "#/$defs/ExpressionTypeTree"
+    $comment: >
+      Open (extensible) shape of EntityAttributeSelectorType, used as the base
+      of concrete profile-defined selector subtypes (e.g. the XPath and
+      JSONPath Profile artifacts).
+
+  EntityAttributeSelectorType:
+    allOf:
+      - $ref: "#/$defs/EntityAttributeSelectorCoreType"
     unevaluatedProperties: false
 
   EntityAttributeSelectorTypeTree:
-    $dynamicRef: "#EntityAttributeSelectorTypeExtensions"
+    type: object
+    required:
+      - EntityAttributeSelector
+    properties:
+      EntityAttributeSelector:
+        $dynamicRef: "#EntityAttributeSelectorTypeExtensions"
+    additionalProperties: false
 
   EntityAttributeSelectorTypeExtensionsDisabled:
     $dynamicAnchor: "EntityAttributeSelectorTypeExtensions"
@@ -462,8 +490,9 @@ $defs:
     oneOf:
       - $ref: "#/$defs/ExpressionTypeTree"
       - type: object
-        required: NamedArgument
-        properties: 
+        required:
+          - NamedArgument
+        properties:
           NamedArgument:
             $ref: "#/$defs/NamedArgumentType"
 
@@ -476,8 +505,7 @@ $defs:
       Name:
         $ref: "#/$defs/LocalIdentifierType"
       Expression:
-        $ref: "#/$defs/ExpressionTypeTree"		
-		
+        $ref: "#/$defs/ExpressionTypeTree"
 
   ApplyTypeTree:
     type: object
@@ -504,24 +532,6 @@ $defs:
     properties:
       EntityAttributeDesignator:
         $ref: "#/$defs/EntityAttributeDesignatorType"
-    additionalProperties: false
-
-  AttributeSelectorTypeTree:
-    type: object
-    required:
-      - AttributeSelector
-    properties:
-      AttributeSelector:
-        $ref: "#/$defs/AttributeSelectorType"
-    additionalProperties: false
-
-  EntityAttributeSelectorTypeTree:
-    type: object
-    required:
-      - EntityAttributeSelector
-    properties:
-      EntityAttributeSelector:
-        $ref: "#/$defs/EntityAttributeSelectorType"
     additionalProperties: false
 
   VariableReferenceTypeTree:
@@ -640,7 +650,7 @@ $defs:
     type: object
     properties:
       Id:
-        $ref": "#/$defs/URIType"
+        $ref: "#/$defs/URIType"
     required:
     - Id
 
@@ -649,8 +659,8 @@ $defs:
     allOf:
     - $ref: "#/$defs/IdReferenceType"
     - properties:
-      Version:
-        $ref: "#/$defs/VersionType"
+        Version:
+          $ref: "#/$defs/VersionType"
       required:
       - Version
     unevaluatedProperties: false
@@ -880,7 +890,7 @@ $defs:
       ShortIdSetReference:
         $ref: "#/$defs/UriArray"
       RequestDefaults:
-          $ref: "#/$defs/RequestDefaultsType"
+        $ref: "#/$defs/RequestDefaultsTypeTree"
       RequestEntity:
         type: array
         items:

--- a/acal-core-yaml-v1.0.md
+++ b/acal-core-yaml-v1.0.md
@@ -2289,7 +2289,7 @@ Properties:
 
 | Property | Required | Type | Cardinality |
 |---|---|---|---|
-| `Category` | Yes | `IdentifierType` | 1 |
+| `Category` | No | `IdentifierType` | 0..1 |
 | `AttributeId` | Yes | `IdentifierType` | 1 |
 | `Issuer` | No | Name | 0..1 |
 | `DataType` | Yes | `IdentifierType` | 1 |

--- a/acal-core-yaml-v1.0.md
+++ b/acal-core-yaml-v1.0.md
@@ -1580,31 +1580,21 @@ PolicyIssuer:
 If `PolicyIssuer` includes structured body content, that content follows
 the `ContentType` rules in [Section 5.4.11](#5411-contenttype-mapping).
 
-### 5.6.8 PolicyPatternMatchReference
+### 5.6.8 PatternMatchIdReferenceType
 
-For conformance-table alignment with the peer representations, YACAL
-uses the name `PolicyPatternMatchReference` for the direct YAML mapping
-of ACAL `PatternMatchIdReferenceType` when it is used as a policy
-reference without parameters.
+ACAL `PatternMatchIdReferenceType` is the base type of
+`PolicyReferenceType` and is not used on its own in YACAL core: policy
+references, with or without `Argument` expressions, use the
+`PolicyReferenceType` representation in
+[Section 5.6.6](#566-policyreferencetype).
 
-It is represented as a YAML mapping with:
+Its YAML mapping defines the following properties, which
+`PolicyReferenceType` inherits:
 
 | Property | Required | Type | Notes |
 |---|---|---|---|
 | `Id` | Yes | URI | Identifier of the referenced policy |
 | `Version` | No | `VersionMatchType` | Matching expression for acceptable versions |
-
-Example:
-
-```yaml
-PolicyPatternMatchReference:
-  Id: "urn:example:yacal:policy:audit-logging"
-  Version: "2.*"
-```
-
-If parameter expressions are required, the `PolicyReferenceType`
-representation in [Section 5.6.6](#566-policyreferencetype) is used
-instead.
 
 ### 5.6.9 PolicyDefaultsType
 

--- a/acal-core-yaml-v1.0.md
+++ b/acal-core-yaml-v1.0.md
@@ -2100,8 +2100,9 @@ Properties:
 If `AppliesTo` is omitted, the notice expression is eligible for either
 `Permit` or `Deny`.
 
-`AttributeAssignmentExpression` items SHOULD be unique by the pair
-`(AttributeId, Category)`.
+`AttributeAssignmentExpression` items MUST be unique by the pair
+`(AttributeId, Category)`, as defined for `NoticeExpressionType` in
+[[ACAL-Core](#acal-core)].
 
 ### 5.9.2 AttributeAssignmentExpressionType
 

--- a/acal-jsonpath-yaml-v1.0-structure.schema.yaml
+++ b/acal-jsonpath-yaml-v1.0-structure.schema.yaml
@@ -12,7 +12,7 @@ $comment: >
 $defs:
   JSONPathAttributeSelectorType:
     allOf:
-      - $ref: "acal-core-yaml-v1.0-structure.schema.yaml#/$defs/AttributeSelectorCoreType"
+      - $ref: "acal-core-yaml-v1.0-structure.schema.yaml#/$defs/AttributeSelectorType"
       - type: object
     unevaluatedProperties: false
     $comment: >
@@ -22,7 +22,7 @@ $defs:
 
   JSONPathEntityAttributeSelectorType:
     allOf:
-      - $ref: "acal-core-yaml-v1.0-structure.schema.yaml#/$defs/EntityAttributeSelectorCoreType"
+      - $ref: "acal-core-yaml-v1.0-structure.schema.yaml#/$defs/EntityAttributeSelectorType"
       - type: object
     unevaluatedProperties: false
     $comment: >

--- a/acal-xpath-yaml-v1.0-structure.schema.yaml
+++ b/acal-xpath-yaml-v1.0-structure.schema.yaml
@@ -66,7 +66,7 @@ $defs:
 
   XPathAttributeSelectorType:
     allOf:
-      - $ref: "acal-core-yaml-v1.0-structure.schema.yaml#/$defs/AttributeSelectorCoreType"
+      - $ref: "acal-core-yaml-v1.0-structure.schema.yaml#/$defs/AttributeSelectorType"
       - type: object
         properties:
           ContextSelectorId:
@@ -75,7 +75,7 @@ $defs:
 
   XPathEntityAttributeSelectorType:
     allOf:
-      - $ref: "acal-core-yaml-v1.0-structure.schema.yaml#/$defs/EntityAttributeSelectorCoreType"
+      - $ref: "acal-core-yaml-v1.0-structure.schema.yaml#/$defs/EntityAttributeSelectorType"
       - type: object
         properties:
           ContextSelectorId:


### PR DESCRIPTION
## Summary

This PR addresses reviewer feedback on `PolicyPatternMatchReference` and fixes the findings of a follow-up audit verifying that YACAL is an accurate instantiation of the ACAL core specification.

### 1. Reviewer feedback: PolicyPatternMatchReference (53f4ee5)

- **acal-core-xml-v4.0-schema.xsd**: removed the `PolicyPatternMatchReference` element — it is only used by the SAML Profile of XACML, which defines its own element. The `PatternMatchIdReferenceType` complexType is retained as the base type of `PolicyReferenceType`; the comment was updated accordingly.
- **acal-core-yaml-v1.0.md (Section 5.6.8)**: renamed the section from *PolicyPatternMatchReference* to *PatternMatchIdReferenceType* and reworded it to describe the type solely as the base type of `PolicyReferenceType`, removing the incorrect statement that `PatternMatchIdReferenceType` is used for policy references without parameters (`PolicyReferenceType` is used both with and without arguments).
- XACML 4.0 and JACAL never mention the element, so no changes were needed there.

### 2. YACAL audit fixes (378d1c2)

**acal-core-yaml-v1.0.md**
- Section 5.10.4: `MissingAttributeDetailType.Category` is optional (0..1) per ACAL core Section 7.44 and the YACAL structure schema; the table wrongly marked it required.

**acal-core-yaml-v1.0-structure.schema.yaml**
- Removed trailing tab characters that made the whole file unparseable as YAML 1.2.
- Removed the duplicate `AttributeSelectorTypeTree` / `EntityAttributeSelectorTypeTree` mapping keys; the merged definitions use the core wrapper key (`AttributeSelector` / `EntityAttributeSelector`, per spec Sections 5.5.10/5.5.11) around the profile extension hook.
- Added `AttributeSelectorCoreType` / `EntityAttributeSelectorCoreType` as the open (extensible) selector shapes that the XPath and JSONPath profile YAML schemas already reference (their `$refs` were dangling).
- Fixed: `required` as a bare string in `ArgumentTypeTree`; a stray quote in a `$ref` keyword in `IdReferenceType`; mis-indentation in `ExactMatchIdReferenceType` that disabled the `Version` type check; `RequestType.RequestDefaults` referencing nonexistent `RequestDefaultsType` (now `RequestDefaultsTypeTree`).

**acal-core-yaml-v1.0-constraints.yaml**
- Fixed five wrong `ACALSection` provenance pointers (7.17→7.12, 7.41→7.37 ×3, 7.42→7.45).

### 3. Alignment with ACAL/XACML semantics (60be3f2)

- **Structure schema**: `PolicyDefaults` and `RequestDefaults` are now arrays of the corresponding defaults trees (minItems 1), matching ACAL core 7.4/7.31 (`[Any Number]`, unique by concrete subtype) and the XML schema (`maxOccurs="unbounded"`). Previously only a single defaults object could validate, so a policy carrying defaults from two profiles had no valid YACAL representation. The YACAL spec text and constraints catalog already described the multi-valued form.
- **Section 5.9.1**: `AttributeAssignmentExpression` items MUST (was SHOULD) be unique by the `(AttributeId, Category)` pair, per the OCL constraint on `NoticeExpressionType` in ACAL core Section 7.29; added the corresponding machine-readable rule `noticeexpression-attributeassignmentexpression-unique`.

## Verification

- The core XSD remains well-formed (`xmllint --noout`).
- All seven YAML artifacts (core structure schema, XPath/JSONPath profile schemas, four composition examples) parse as YAML 1.2 with no duplicate mapping keys, and all internal and cross-file `$refs` resolve.
- No remaining references to `PolicyPatternMatchReference` outside `published/` and `archive/`.

## Related (not in this PR)

ACAL core prose-vs-UML inconsistencies found during the audit (Sections 7.12, 7.29, 7.37, 7.42, 7.45, conformance table 11.2.1) and the corresponding JACAL defaults-cardinality fix are being filed as separate issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
