### PR TITLE
Fix #94: NoticeExpression/Notice Id is not required to be unique

### DIFF
--- a/acal-adoption-guide.md
+++ b/acal-adoption-guide.md
@@ -1067,25 +1067,26 @@ Rule:
   `AttributeAssignmentExpression`; when absent it participates in the uniqueness
   check as an absent value — meaning two entries with the same `AttributeId` and no
   `Category` both present would violate the constraint.
-- `NoticeExpression` Ids MUST be unique within their enclosing `Policy` or `Rule`
-  (OCL: `self->isUnique(Id)`; see the UML comment in [Section 7.4 PolicyType](#74-policytype)
-  of the ACAL Core specification). When the same notification action is needed for
-  multiple recipients or payloads, use **distinct** `NoticeExpression` Ids and add an
-  `AttributeAssignmentExpression` (e.g. `AttributeId="action"` with `Value="send-mail"`)
-  to identify the shared action/notification type. The distinct Ids enable unambiguous
-  reference, logging, and troubleshooting; the common `AttributeAssignment` value
-  conveys the shared intent.
+- `NoticeExpression` Ids are **not** required to be unique within a `Policy` or `Rule`.
+  The `Id` identifies what the notice *means* to the PEP — what it must do, or is being
+  informed of — exactly as `ObligationId` did in XACML 3.0. It is a *concept* identifier,
+  not an instance identifier, so a policy MAY emit the same notice `Id` more than once with
+  different `AttributeAssignmentExpression`s. The uniqueness constraint that *does* apply is
+  on `(AttributeId, Category)` pairs **within** a single notice, not on notice Ids across the
+  enclosing policy or rule.
 
 ---
 
-#### Variant: Multiple Notices Sharing an Action Type
+#### Variant: Emitting the Same Notice Twice with Different Arguments
 
-When the same notification action (e.g. "send-mail") must be invoked for multiple
-recipients or with different payloads, create one `NoticeExpression` **per recipient**
-with a **distinct** `Id`. Use a shared `AttributeAssignmentExpression` (e.g.
-`AttributeId="action" Value="send-mail"`) to semantically tie them together. This
-keeps `NoticeExpression` Ids unique (per the core spec recommendation) for unambiguous
-reference, logging, and troubleshooting.
+When the same obligation (e.g. "send-mail") must be discharged for multiple recipients or
+with different payloads, emit one `NoticeExpression` **per recipient**, all carrying the
+**same** `Id`. The `Id` names the obligation — it is what tells the PEP to send mail — and
+the `AttributeAssignmentExpression`s carry the per-instance data that differs between them.
+
+This is the same shape as an XACML 3.0 `ObligationId`, so obligations already defined by
+existing profiles (e.g. `add-history` from the separation-of-duties profile) can be emitted
+repeatedly without inventing a new identifier for each occurrence.
 
 **Plain language**: A physician may write to a patient chart. When they do, an email
 notification must be sent to both the patient and the patient's next of kin.
@@ -1114,11 +1115,8 @@ notification must be sent to both the patient and the patient's next of kin.
       </Apply>
     </Apply>
   </Condition>
-  <NoticeExpression Id="urn:example:notice:notify-patient"
+  <NoticeExpression Id="urn:example:notice:send-mail"
                    AppliesTo="Permit" IsObligation="true">
-    <AttributeAssignmentExpression AttributeId="urn:example:notice:action">
-      <Value>send-mail</Value>
-    </AttributeAssignmentExpression>
     <AttributeAssignmentExpression AttributeId="urn:example:notice:mailto">
       <AttributeDesignator
         Category="{resource}" AttributeId="{patient-email}" MustBePresent="true"/>
@@ -1127,11 +1125,8 @@ notification must be sent to both the patient and the patient's next of kin.
       <Value>Your medical chart was updated by your physician.</Value>
     </AttributeAssignmentExpression>
   </NoticeExpression>
-  <NoticeExpression Id="urn:example:notice:notify-next-of-kin"
+  <NoticeExpression Id="urn:example:notice:send-mail"
                    AppliesTo="Permit" IsObligation="true">
-    <AttributeAssignmentExpression AttributeId="urn:example:notice:action">
-      <Value>send-mail</Value>
-    </AttributeAssignmentExpression>
     <AttributeAssignmentExpression AttributeId="urn:example:notice:mailto">
       <AttributeDesignator
         Category="{resource}" AttributeId="{next-of-kin-email}" MustBePresent="true"/>
@@ -1178,14 +1173,10 @@ notification must be sent to both the patient and the patient's next of kin.
     },
     "NoticeExpression": [
       {
-        "Id": "urn:example:notice:notify-patient",
+        "Id": "urn:example:notice:send-mail",
         "AppliesTo": "Permit",
         "IsObligation": true,
         "AttributeAssignmentExpression": [
-          {
-            "AttributeId": "urn:example:notice:action",
-            "Expression": { "Value": "send-mail" }
-          },
           {
             "AttributeId": "urn:example:notice:mailto",
             "Expression": {
@@ -1203,14 +1194,10 @@ notification must be sent to both the patient and the patient's next of kin.
         ]
       },
       {
-        "Id": "urn:example:notice:notify-next-of-kin",
+        "Id": "urn:example:notice:send-mail",
         "AppliesTo": "Permit",
         "IsObligation": true,
         "AttributeAssignmentExpression": [
-          {
-            "AttributeId": "urn:example:notice:action",
-            "Expression": { "Value": "send-mail" }
-          },
           {
             "AttributeId": "urn:example:notice:mailto",
             "Expression": {
@@ -1259,13 +1246,10 @@ Rule:
                   Category: "{action}"
                   AttributeId: "{action-id}"
   NoticeExpression:
-    - Id: "urn:example:notice:notify-patient"
+    - Id: "urn:example:notice:send-mail"
       AppliesTo: Permit
       IsObligation: true
       AttributeAssignmentExpression:
-        - AttributeId: "urn:example:notice:action"
-          Expression:
-            Value: send-mail
         - AttributeId: "urn:example:notice:mailto"
           Expression:
             AttributeDesignator:
@@ -1275,13 +1259,10 @@ Rule:
         - AttributeId: "urn:example:notice:message"
           Expression:
             Value: Your medical chart was updated by your physician.
-    - Id: "urn:example:notice:notify-next-of-kin"
+    - Id: "urn:example:notice:send-mail"
       AppliesTo: Permit
       IsObligation: true
       AttributeAssignmentExpression:
-        - AttributeId: "urn:example:notice:action"
-          Expression:
-            Value: send-mail
         - AttributeId: "urn:example:notice:mailto"
           Expression:
             AttributeDesignator:
@@ -1295,17 +1276,19 @@ Rule:
 
 **What this shows**
 
-- Two `NoticeExpression` entries with distinct Ids (`notify-patient`, `notify-next-of-kin`)
-  satisfy the `isUnique(Id)` constraint. The shared `AttributeAssignmentExpression`
-  (`action = send-mail`) conveys to the PEP that both obligations invoke the same
-  notification mechanism — the unique Ids keep them individually addressable for logging
-  and error reporting.
-- The only difference between the two notices is `mailto` and `message`. The `action`
-  assignment is identical across both — this is the type-tag pattern for grouping notices
-  of the same kind without duplicating Ids.
-- A PEP receiving two `send-mail` obligations can dispatch them independently. If one
-  fails, the unique Id in the error report identifies exactly which recipient was not
-  notified.
+- Both `NoticeExpression` entries carry the **same** `Id` (`urn:example:notice:send-mail`).
+  This is legal: notice Ids are not required to be unique within a policy or rule. The `Id`
+  is what tells the PEP *which obligation to discharge* — send mail — so both entries route
+  to the same PEP handler.
+- The two notices differ only in `mailto` and `message`. Those `AttributeAssignmentExpression`s
+  are the per-instance data; the `Id` is the concept. No separate `action` assignment is needed
+  to tag the notification type, because the `Id` already carries that meaning.
+- A PEP receiving two `send-mail` obligations dispatches them independently — once per
+  recipient. The obligations are distinguished by their arguments, not by their `Id`.
+- Because the `Id` behaves exactly like an XACML 3.0 `ObligationId`, obligations defined by
+  existing profiles work unchanged: a policy can emit `add-history` twice with different
+  parameters, or the same obligation from two rules that permit access for two different
+  reasons.
 
 ---
 

--- a/acal-core-json-v1.0-schema.json
+++ b/acal-core-json-v1.0-schema.json
@@ -455,7 +455,6 @@
 					"$ref": "#/$defs/EffectType"
 				},
 				"NoticeExpression": {
-					"$comment": "TODO: add 'uniqueKeys': ['/Id'] from ArrayExt vocabulary - https://docs.json-everything.net/schema/vocabs/array-ext/",
 					"type": "array",
 					"minItems": 1,
 					"items": {
@@ -533,7 +532,6 @@
 					}
 				},
 				"NoticeExpression": {
-					"$comment": "TODO: add 'uniqueKeys': ['/Id'] from ArrayExt vocabulary - https://docs.json-everything.net/schema/vocabs/array-ext/",
 					"type": "array",
 					"minItems": 1,
 					"items": {
@@ -1355,7 +1353,6 @@
 					"$ref": "#/$defs/StatusType"
 				},
 				"Notice": {
-					"$comment": "TODO: add 'uniqueKeys': ['/Id'] from ArrayExt vocabulary - https://docs.json-everything.net/schema/vocabs/array-ext/",
 					"type": "array",
 					"minItems": 1,
 					"items": {

--- a/acal-core-v1.0.md
+++ b/acal-core-v1.0.md
@@ -3725,18 +3725,18 @@ OCL v2.4, Section 11.2.3: "by virtue of the implicit conversion to a collection 
 '/
 'A CombinerInput is not always unique: there may be two PolicyReferences to the same parameterized Policy but with different arguments (so the same PolicyId occurs twice).
 /'
-A NoticeExpression has a unique Id. In case you need to call the same action twice but with different arguments (AttributeAssignments) in a sequence of Notices, simply use an AttributeAssignment to identify the action, but keep the NoticeExpression Id unique (which helps with troubleshooting). For example, two notices calling the same action (send mail) but with different args (different content sent to different recipients) (N.B.: this is pseudo-code for brevity, not an official syntax):
+A NoticeExpression Id is not unique. The Id is a *concept* identifier: it tells the PEP what the notice means and how the PEP is to process it (as the ObligationId did in XACML 3.0), rather than identifying a particular occurrence of the notice. The same Id may therefore appear more than once, typically with different AttributeAssignmentExpressions. For example (N.B.: this is pseudo-code for brevity, not an official syntax), one policy sending the same kind of mail to two different recipients with different content:
 
-- NoticeExpression Id="send_mail_to_a"
-   - AttributeAssignmentExpression AttributeId="action"  Value="mail"
+- NoticeExpression Id="send_mail"
    - AttributeAssignmentExpression AttributeId="recipients" Value="a@example.com"
    - AttributeAssignmentExpression AttributeId="body" Value="blablabla"
    ... other args...
-- NoticeExpression Id="send_mail_to_b"
-   - AttributeAssignmentExpression AttributeId="action"  Value="mail"
+- NoticeExpression Id="send_mail"
    - AttributeAssignmentExpression AttributeId="recipients" Value="b@example.com"
    - AttributeAssignmentExpression AttributeId="body" Value="foobar"
-   ... other args... 
+   ... other args...
+
+Likewise, two Rules of the same Policy may each emit the same notice for two different reasons.
 '/
 class PolicyType <<dataType>> extends CombinerInputType {
   {field} + PolicyId: URI [1]
@@ -3751,7 +3751,7 @@ class PolicyType <<dataType>> extends CombinerInputType {
   {field} + Target: BooleanExpressionType [0..1]
   {field} + CombiningAlgId: IdentifierType [1]
   {field} + CombinerInput: CombinerInputType [*] {ordered, nonunique}
-  {field} + NoticeExpression: NoticeExpressionType [*] {ordered, unique} {{OCL} self->isUnique(Id)}
+  {field} + NoticeExpression: NoticeExpressionType [*] {ordered, nonunique}
 }
 
 abstract class CombinerInputType <<dataType>>
@@ -3812,7 +3812,7 @@ URIs starting with `urn:oasis:names:tc:xacml:` or `urn:oasis:names:tc:acal:` are
 
 `NoticeExpression` [Any Number]
 
-: A sequence of `NoticeExpressionType` objects to be evaluated into notices by the PDP. Each object's `Id` MUST be unique in this sequence. See [Section 7.29](#729-noticeexpressiontype). See [Section 8.16](#816-notices) for a description of how the notices to be returned by the PDP are determined.
+: A sequence of `NoticeExpressionType` objects to be evaluated into notices by the PDP. Objects' `Id` values are not required to be unique in this sequence; the same `Id` MAY occur more than once, typically with different `AttributeAssignmentExpression`s. See [Section 7.29](#729-noticeexpressiontype). See [Section 8.16](#816-notices) for a description of how the notices to be returned by the PDP are determined.
 
 `CombinerInput` [Any Number]
 
@@ -4024,13 +4024,16 @@ UML definition (class diagram):
 @startuml
 hide empty members 
 hide circle
+/'
+NoticeExpression (Id) is not unique for the same reason as in PolicyType, and Notices may be in sequence (ordered).
+'/
 class RuleType <<dataType>> {
   {field} + Id: LocalIdentifierType [1]
   {field} + Description: String [0..1]
   {field} + VariableDefinition: VariableDefinitionType [*] {ordered, unique} {{OCL} self->isUnique(VariableId)}
   {field} + Condition: BooleanExpressionType [0..1]
   {field} + Effect: EffectType [1]
-  {field} + NoticeExpression: NoticeExpressionType [*] {ordered, unique} {{OCL} self->isUnique(Id)}
+  {field} + NoticeExpression: NoticeExpressionType [*] {ordered, nonunique}
 }
 @enduml
 ```
@@ -4059,7 +4062,7 @@ A `RuleType` object contains the following properties:
 
 `NoticeExpression` [Any Number]
 
-: A sequence of `NoticeExpressionType` objects, each defining a notice expression potentially evaluated into a notice by the PDP. See [NoticeExpressionType](#noticeexpressiontype). Each object's `Id` MUST be unique in this sequence. See [Section 8.16](#816-notices) for a description of how the notices to be returned by the PDP shall be determined. See [Section 8.2](#82-policy-enforcement-point) about enforcement of obligation notices.
+: A sequence of `NoticeExpressionType` objects, each defining a notice expression potentially evaluated into a notice by the PDP. See [NoticeExpressionType](#noticeexpressiontype). Objects' `Id` values are not required to be unique in this sequence; the same `Id` MAY occur more than once, typically with different `AttributeAssignmentExpression`s. See [Section 8.16](#816-notices) for a description of how the notices to be returned by the PDP shall be determined. See [Section 8.2](#82-policy-enforcement-point) about enforcement of obligation notices.
 
 ## 7.13 VariableDefinitionType
 
@@ -4777,7 +4780,7 @@ A `NoticeType` object contains the following properties:
 
 `Id` [Required]
 
-: An `IdentifierType` value specifying an identifier for the notice that the PEP associates with particular processing requirements or informational content.
+: An `IdentifierType` value specifying an identifier for the notice that the PEP associates with particular processing requirements or informational content. The `Id` identifies the *semantics* of the notice — what the PEP is required to do, or is being informed of — rather than a particular occurrence of it. The same `Id` MAY therefore appear on more than one notice in a result, typically with different `AttributeAssignment`s.
 `Id` values starting with `urn:oasis:names:tc:xacml:` or `urn:oasis:names:tc:acal:` are reserved by the XACML TC for their exclusive use.
 
 `IsObligation` [Optional, Default `false`]
@@ -4880,7 +4883,7 @@ A `NoticeExpressionType` object contains the following properties:
 
 `Id` [Required]
 
-: An `IdentifierType` value nominating the identifier for the notice that the PEP associates with particular processing requirements or informational content.
+: An `IdentifierType` value nominating the identifier for the notice that the PEP associates with particular processing requirements or informational content. The `Id` identifies the *semantics* of the notice — what the PEP is required to do, or is being informed of — rather than a particular occurrence of it. The same `Id` MAY therefore appear on more than one `NoticeExpression` within a policy or rule, typically with different `AttributeAssignmentExpression`s.
 `Id` values starting with `urn:oasis:names:tc:xacml:` or `urn:oasis:names:tc:acal:` are reserved by the XACML TC for their exclusive use.
 
 `IsObligation` [Optional]
@@ -5149,7 +5152,7 @@ hide circle
 class ResultType <<dataType>> {
   {field} + Decision: DecisionType [1]
   {field} + Status: StatusType [0..1]
-  {field} + Notice: NoticeType [*] {ordered, unique} {{OCL} self->isUnique(Id)}
+  {field} + Notice: NoticeType [*] {ordered, nonunique}
   {field} + ResultEntity: ResultEntityType [*] {unordered, unique} {{OCL} self->isUnique(Category)}
   {field} + ApplicablePolicyReference: ExactMatchIdReferenceType [*] {unordered, unique} {{OCL} self->isUnique(Id)}
 }
@@ -5168,7 +5171,7 @@ A `ResultType` object contains the following properties:
 
 `Notice` [Any Number]
 
-: A sequence of `NoticeType` objects, each a notice to be interpreted by the PEP. Each object's `Id` MUST be unique in the sequence. See [Section 7.26](#noticetype). If the PEP does not understand or cannot fulfill an obligation notice, then the action of the PEP is determined by its bias, see [Section 8.2](#82-policy-enforcement-point). If the PEP does not understand an advice notice, the PEP may safely ignore the notice. See [Section 8.16](#816-notices) for a description of how the list of notices to be returned by the PDP is determined.
+: A sequence of `NoticeType` objects, each a notice to be interpreted by the PEP. Objects' `Id` values are not required to be unique in the sequence; the same `Id` MAY occur more than once, typically with different `AttributeAssignment`s, for instance when it is drawn from more than one rule or policy. See [Section 7.26](#noticetype). If the PEP does not understand or cannot fulfill an obligation notice, then the action of the PEP is determined by its bias, see [Section 8.2](#82-policy-enforcement-point). If the PEP does not understand an advice notice, the PEP may safely ignore the notice. See [Section 8.16](#816-notices) for a description of how the list of notices to be returned by the PDP is determined.
 
 `ResultEntity` [Any Number]
 

--- a/acal-core-xml-v4.0-schema.xsd
+++ b/acal-core-xml-v4.0-schema.xsd
@@ -679,12 +679,13 @@ which is to be used in Results (no Content or IncludeInResult attributes).
 			<xs:selector xpath="xacml:Rule" />
 			<xs:field xpath="@Id" />
 		</xs:key>
-		<xs:key name="Policy_NoticeExpression_Id">
-			<xs:selector xpath="xacml:NoticeExpression" />
-			<xs:field xpath="@Id" />
-		</xs:key>
 		<!--
-			Other uniqueness constraint(s) considered:
+			Other uniqueness constraints considered:
+			- NoticeExpression (Id): not unique. The Id is a concept identifier: it tells the PEP what the
+		notice means and how to process it (as ObligationId did in XACML 3.0), not which occurrence it is.
+		The same Id may therefore occur more than once, typically with different AttributeAssignmentExpressions
+		(e.g. mail the same kind of message to different recipients), or be emitted from two Rules of the same
+		Policy for two different reasons.
 			- CombinerInput: not always unique: there may be two PolicyReferences to the same parameterized
 		Policy but with different arguments, so the same PolicyId may occur twice.
 		-->
@@ -757,10 +758,10 @@ which is to be used in Results (no Content or IncludeInResult attributes).
 			<xs:selector xpath="xacml:VariableDefinition" />
 			<xs:field xpath="@VariableId" />
 		</xs:key>
-		<xs:key name="Rule_NoticeExpression_Id">
-			<xs:selector xpath="xacml:NoticeExpression" />
-			<xs:field xpath="@Id" />
-		</xs:key>
+		<!--
+		Other possible uniqueness constraints considered:
+		- NoticeExpression (Id): is not unique, for the same reason as in PolicyType.
+		-->
 	</xs:element>
 	<xs:complexType name="RuleType">
 		<xs:sequence>

--- a/acal-core-yaml-v1.0-constraints.yaml
+++ b/acal-core-yaml-v1.0-constraints.yaml
@@ -499,20 +499,6 @@ Rule:
       YACALSection: "5.6.6"
       ACALSection: "7.11"
 
-  - Id: "rule-noticeexpression-id-unique"
-    Kind: uniqueByProperty
-    Severity: error
-    AppliesTo:
-      ObjectType: RuleType
-      CollectionPath: "$.Policy.CombinerInput[].Rule.NoticeExpression"
-    KeyProperties:
-      - Id
-    Requirement: >
-      NoticeExpression Id values within a RuleType MUST be unique.
-    Provenance:
-      YACALSection: "5.9.1"
-      ACALSection: "7.12"
-
   - Id: "noticeexpression-attributeassignmentexpression-unique"
     Kind: uniqueByProperty
     Severity: error
@@ -529,34 +515,6 @@ Rule:
     Provenance:
       YACALSection: "5.9.1"
       ACALSection: "7.29"
-
-  - Id: "policy-noticeexpression-id-unique"
-    Kind: uniqueByProperty
-    Severity: error
-    AppliesTo:
-      ObjectType: PolicyType
-      CollectionPath: "$.Policy.NoticeExpression"
-    KeyProperties:
-      - Id
-    Requirement: >
-      NoticeExpression Id values within a PolicyType MUST be unique.
-    Provenance:
-      YACALSection: "5.9.1"
-      ACALSection: "7.4"
-
-  - Id: "result-notice-id-unique"
-    Kind: uniqueByProperty
-    Severity: error
-    AppliesTo:
-      ObjectType: ResultType
-      CollectionPath: "$.Response.Result[].Notice"
-    KeyProperties:
-      - Id
-    Requirement: >
-      Notice Id values within a ResultType MUST be unique.
-    Provenance:
-      YACALSection: "5.9.3"
-      ACALSection: "7.37"
 
   - Id: "result-resultentity-category-unique"
     Kind: uniqueByProperty

--- a/archive/acal-core-v1.0.puml
+++ b/archive/acal-core-v1.0.puml
@@ -107,7 +107,7 @@ package "PDP Configuration" {
     PolicyType *-- "*" VariableDefinitionType: VariableDefinition\n{ordered,unique}
     PolicyType *-- "0..1" BooleanExpressionType: Target
     PolicyType *-- "*" CombinerInputType: CombinerInput\n{ordered}
-    PolicyType *-- "*" NoticeExpressionType: NoticeExpression\n{ordered,unique}
+    PolicyType *-- "*" NoticeExpressionType: NoticeExpression\n{ordered}
     
     'WARNING: CHANGE!!!!
     class RuleType implements CombinerInputType {
@@ -286,7 +286,7 @@ package "PDP API (used by PEPs)" {
     }
     ResultType *-- "0..1" StatusType: Status
     ResultType *-- "*" ResultEntityType: ResultEntity\n{unique}
-    ResultType *-- "*" NoticeType: Notice\n{ordered, unique}
+    ResultType *-- "*" NoticeType: Notice\n{ordered}
     ResultType *-- "*" ExactMatchIdReferenceType: ApplicablePolicyReference\n{unique}
 
     class ResponseType #LightSkyBlue


### PR DESCRIPTION
Reverses the isUnique(Id) constraint added in 851ebc9 and propagated to the adoption guide in b18095d, per Steven Legg's objection on issue #94.

A notice Id is a concept identifier: it names what the obligation means and how the PEP must process it, exactly as ObligationId did in XACML 3.0. It is not an instance identifier. Requiring uniqueness forces the obligation's semantics out of the Id and into an overloaded AttributeAssignment, which makes the published ObligationId URIs of existing profiles meaningless and blocks legitimate patterns (emitting add-history twice with different parameters, or the same obligation from two rules for two different reasons).

It also contradicts the evaluation model: Section 8.16 passes notices up from rule to policy to Result, so two rules emitting the same-Id obligation makes a unique-by-Id ResultType unrepresentable, and no de-duplication rule exists.

Removed the constraint from every place it was encoded:
- acal-core-v1.0.md: UML/OCL and prose for PolicyType (7.4), RuleType (7.12) and ResultType (7.37), back to {ordered, nonunique}
- acal-core-xml-v4.0-schema.xsd: Policy_NoticeExpression_Id and Rule_NoticeExpression_Id keys
- acal-core-yaml-v1.0-constraints.yaml: the three uniqueByProperty rules
- acal-core-json-v1.0-schema.json: the three uniqueKeys TODO comments
- archive/acal-core-v1.0.puml: {unique} on the Notice associations

Added a note to 7.26 and 7.29 stating that the Id identifies the semantics of the notice rather than an occurrence of it, so the same Id may legitimately appear more than once. Reframed the adoption guide's notice example, which previously existed to teach the distinct-Id workaround, to demonstrate the same-Id pattern across XML, JSON and YAML.