### PR TITLE
Fix #102: NoticeType AttributeAssignment uniqueness enforcement gap

### DIFF
--- a/acal-core-xml-v4.0-schema.xsd
+++ b/acal-core-xml-v4.0-schema.xsd
@@ -422,6 +422,17 @@ which is to be used in Results (no Content or IncludeInResult attributes).
 		Short Identifiers -->
 		<xs:attribute name="Id" type="xacml:IdentifierType" use="required" />
 		<xs:attribute name="IsObligation" type="xs:boolean" use="optional" default="false" />
+		<!-- Issue #102: xs:unique cannot express uniqueness over a key that includes an optional
+		field, so it does not catch duplicate AttributeId when Category is absent from both. This
+		assert covers that case; XSD 1.0 processors must rely on the Schematron rule instead. -->
+		<xs:assert vc:minVersion="1.1"
+			test="every $elt in xacml:AttributeAssignment satisfies (every $following in $elt/following-sibling::xacml:AttributeAssignment satisfies not($elt/@AttributeId = $following/@AttributeId and ((not($elt/@Category) and not($following/@Category)) or $elt/@Category = $following/@Category)))">
+			<xs:annotation>
+				<xs:documentation xml:lang="en"> ACAL constraint on Notice property: {OCL}
+					self->isUnique(AttributeAssignment->collect(Sequence{AttributeId, Category}))
+					</xs:documentation>
+			</xs:annotation>
+		</xs:assert>
 	</xs:complexType>
 
 	<xs:element name="AttributeAssignment" type="xacml:AttributeAssignmentType" />

--- a/acal-core-xml-v4.0-schematron.sch
+++ b/acal-core-xml-v4.0-schematron.sch
@@ -143,4 +143,14 @@
 	  <assert test="every $elt in xacml:AttributeAssignmentExpression satisfies (every $following in $elt/following-sibling::xacml:AttributeAssignmentExpression satisfies not($elt/@AttributeId = $following/@AttributeId and ((not($elt/@Category) and not($following/@Category)) or $elt/@Category = $following/@Category)))">Duplicate AttributeAssignmentExpression (AttributeId, Category) pair</assert>
 	</rule>
  </pattern>
+ <pattern id="ACAL_constraint_on_NoticeType_AttributeAssignment_property">
+ 	<title>ACAL constraint on NoticeType property: {OCL} self-&gt;isUnique(AttributeAssignment-&gt;collect(Sequence{AttributeId, Category}))</title>
+	<rule context="xacml:Notice">
+		<!--
+		Issue #102: complements the XSD's xs:unique constraint, which cannot catch a duplicate
+		AttributeId when Category is absent from both AttributeAssignment elements.
+		-->
+	  <assert test="every $elt in xacml:AttributeAssignment satisfies (every $following in $elt/following-sibling::xacml:AttributeAssignment satisfies not($elt/@AttributeId = $following/@AttributeId and ((not($elt/@Category) and not($following/@Category)) or $elt/@Category = $following/@Category)))">Duplicate AttributeAssignment (AttributeId, Category) pair</assert>
+	</rule>
+ </pattern>
 </schema>

--- a/acal-core-yaml-v1.0-constraints.yaml
+++ b/acal-core-yaml-v1.0-constraints.yaml
@@ -516,6 +516,23 @@ Rule:
       YACALSection: "5.9.1"
       ACALSection: "7.29"
 
+  - Id: "notice-attributeassignment-unique"
+    Kind: uniqueByProperty
+    Severity: error
+    AppliesTo:
+      ObjectType: NoticeType
+      CollectionPath: "$.Response.Result[].Notice[].AttributeAssignment"
+    KeyProperties:
+      - AttributeId
+      - Category
+    Requirement: >
+      AttributeAssignment values within a NoticeType MUST be unique by the
+      (AttributeId, Category) pair. An absent Category participates in the
+      pair as an absent value.
+    Provenance:
+      YACALSection: "5.9.3"
+      ACALSection: "7.26"
+
   - Id: "result-resultentity-category-unique"
     Kind: uniqueByProperty
     Severity: error


### PR DESCRIPTION
## Summary
- Companion fix to #99, closing the identical `xs:unique`-cannot-see-absent-`Category` enforcement gap for `NoticeType.AttributeAssignment` (the resolved/runtime `Notice`) rather than `NoticeExpressionType.AttributeAssignmentExpression` (the policy-time `NoticeExpression`, fixed by #99).
- Adds an `xs:assert` (XSD 1.1) on `NoticeType`, a matching Schematron rule for XSD 1.0-only consumers, and a `notice-attributeassignment-unique` entry in `acal-core-yaml-v1.0-constraints.yaml` (the YACAL side had no entry at all for this constraint until now, unlike the `NoticeExpressionType` case).
- No normative example needed fixing — `Notice` is a PDP-resolved runtime object that doesn't appear in hand-written policy examples, so this PR is enforcement-gap only.

Closes #102.

## Test plan
- [x] `xmllint --noout` on the modified `.xsd` and `.sch` files (well-formedness).
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the modified constraints YAML.
- [x] Isolated the new `xs:assert`'s exact XPath in a minimal standalone XSD 1.1 schema and verified with `xmlschema.XMLSchema11` against 3 hand-built pass/fail cases (duplicate w/o Category → invalid; duplicate w/ matching Category → invalid; duplicate w/ differing Category → valid).
- [x] Ran the identical XPath 2.0 expression (shared by the `xs:assert` and the Schematron `assert`) through Saxon against synthetic `Notice` XML instances: a duplicate-`AttributeId`-no-`Category` case correctly reports `valid=false`, a legitimate case reports `valid=true`.
