### PR TITLE
Changes per suggested solution:

### DIFF
--- a/acal-core-json-v1.0-schema.json
+++ b/acal-core-json-v1.0-schema.json
@@ -1386,7 +1386,7 @@
 			],
 			"properties": {
 				"RequestReference": {
-					"$comment": "TODO: translate/enforce ACAL constraint: {OCL} self->isUnique(RequestEntityReference->collect(Id)->asSet())",
+					"$comment": "TODO: translate/enforce ACAL constraint: {OCL} self->isUnique(RequestEntityReference->asSet())",
 					"type": "array",
 					"minItems": 1,
 					"items": {
@@ -1404,24 +1404,12 @@
 			],
 			"properties": {
 				"RequestEntityReference": {
-					"$comment": "TODO: add 'uniqueKeys': ['/Id'] from ArrayExt vocabulary - https://docs.json-everything.net/schema/vocabs/array-ext/",
 					"type": "array",
 					"minItems": 1,
+					"uniqueItems": true,
 					"items": {
-						"$ref": "#/$defs/RequestEntityReferenceType"
+						"$ref": "#/$defs/LocalIdentifierType"
 					}
-				}
-			},
-			"additionalProperties": false
-		},
-		"RequestEntityReferenceType": {
-			"type": "object",
-			"required": [
-				"Id"
-			],
-			"properties": {
-				"Id": {
-					"$ref": "#/$defs/LocalIdentifierType"
 				}
 			},
 			"additionalProperties": false

--- a/acal-core-v1.0.md
+++ b/acal-core-v1.0.md
@@ -257,15 +257,14 @@ Copyright © OASIS Open 2026. All Rights Reserved.  For license and copyright in
   - [7.37 ResultType](#737-resulttype)
   - [7.38 MultiRequestsType (optional)](#738-multirequeststype-optional)
   - [7.39 RequestReferenceType (optional)](#739-requestreferencetype-optional)
-  - [7.40 RequestEntityReferenceType (optional)](#740-requestentityreferencetype-optional)
-  - [7.41 StatusType](#741-statustype)
-  - [7.42 StatusCodeType](#742-statuscodetype)
-  - [7.43 StatusDetailType (optional)](#743-statusdetailtype-optional)
-  - [7.44 MissingAttributeDetailType](#744-missingattributedetailtype)
-  - [7.45 ResultEntityType](#745-resultentitytype)
-  - [7.46 EntityType](#746-entitytype)
-  - [7.47 BundleType](#747-bundletype)
-  - [7.48 ArgumentType and NamedArgumentType](#748-argumenttype-and-namedargumenttype)
+  - [7.40 StatusType](#740-statustype)
+  - [7.41 StatusCodeType](#741-statuscodetype)
+  - [7.42 StatusDetailType (optional)](#742-statusdetailtype-optional)
+  - [7.43 MissingAttributeDetailType](#743-missingattributedetailtype)
+  - [7.44 ResultEntityType](#744-resultentitytype)
+  - [7.45 EntityType](#745-entitytype)
+  - [7.46 BundleType](#746-bundletype)
+  - [7.47 ArgumentType and NamedArgumentType](#747-argumenttype-and-namedargumenttype)
 - [8 Functional Requirements](#8-functional-requirements)
   - [8.1 Unicode Issues](#81-unicode-issues)
     - [8.1.1 Normalization](#811-normalization)
@@ -5195,7 +5194,7 @@ UML definition (class diagram):
 hide empty members 
 hide circle
 class MultiRequestsType <<dataType>> {
-   + RequestReference: RequestReferenceType [1..*] {unordered, unique} {{OCL} self->isUnique(RequestEntityReference->collect(Id)->asSet())}
+   + RequestReference: RequestReferenceType [1..*] {unordered, unique} {{OCL} self->isUnique(RequestEntityReference->asSet())}
 }
 @enduml
 ```
@@ -5220,7 +5219,7 @@ UML definition (class diagram):
 hide empty members 
 hide circle
 class RequestReferenceType <<dataType>> {
-   + RequestEntityReference: RequestEntityReferenceType [1..*] {unordered, unique} {{OCL} self->isUnique(Id)}
+   + RequestEntityReference: LocalIdentifierType [1..*] {unordered, unique}
 }
 @enduml
 ```
@@ -5229,37 +5228,9 @@ A `RequestReferenceType` object contains the following properties:
 
 `RequestEntityReference` [one to many]
 
-: A sequence of `RequestEntityReferenceType` objects, each a reference to a `RequestEntityType` object in the enclosing `RequestType` object. See [Section 7.40](#requestentityreferencetype).
+: A sequence of `LocalIdentifierType` values, each referencing a `RequestEntityType` object in the enclosing `RequestType` object by the value of its `Id` property.
 
-<a name="requestentityreferencetype"></a>
-
-## 7.40 RequestEntityReferenceType (optional)
-
-_**Support for this object is optional.**_
-
-A `RequestEntityReferenceType` object makes a reference to a `RequestEntityType` object. The meaning of this object is defined in [[Multi](#multi)].
-
-UML definition (class diagram):
-```plantuml
-@startuml
-hide empty members 
-hide circle
-class RequestEntityType <<dataType>> 
-class RequestEntityReferenceType <<dataType>> {
-   + Id: LocalIdentifierType [1]
-}
-
-RequestEntityReferenceType "Id *" --> "Id 1" RequestEntityType: reference
-@enduml
-```
-
-A `RequestEntityReferenceType` object contains the following properties:
-
-`Id` [Required]
-
-: A `LocalIdentifierType` value referencing a `RequestEntityType` object in the enclosing `RequestType` object by the value of its `Id` property.
-
-## 7.41 StatusType
+## 7.40 StatusType
 
 A `StatusType` object represents the status of the authorization decision result.
 
@@ -5290,7 +5261,7 @@ A `StatusType` object contains the following properties:
 
 : A `StatusDetailType` object containing additional status information.
 
-## 7.42 StatusCodeType
+## 7.41 StatusCodeType
 
 A `StatusCodeType` object contains a major status code value and an optional recursive series of minor status codes.
 
@@ -5317,7 +5288,7 @@ A `StatusCodeType` object contains the following properties:
 
 : A `StatusCodeType` object describing a minor status code, which qualifies its parent status code. Minor status codes may be nested recursively this way.
 
-## 7.43 StatusDetailType (optional)
+## 7.42 StatusDetailType (optional)
 
 _**Support for this object type is optional.**_
 
@@ -5376,7 +5347,7 @@ A PDP MUST NOT return a `StatusDetailType` object in conjunction with the `proce
 
 <a name="missingattributedetailtype"></a>
 
-## 7.44 MissingAttributeDetailType
+## 7.43 MissingAttributeDetailType
 
 A `MissingAttributeDetailType` object conveys information about attributes required for policy evaluation that were missing from the request context.
 
@@ -5423,7 +5394,7 @@ A `MissingAttributeDetailType` object contains the following properties:
 
 If the PDP includes `ValueType` objects in the `MissingAttributeDetailType` object, then this indicates the acceptable values for that attribute. If no `ValueType` objects are included, then the `MissingAttributeDetailType` object indicates the names of attributes that the PDP failed to resolve during its evaluation. The list of attributes may be partial or complete. There is no guarantee by the PDP that supplying the missing values or attributes will be sufficient to satisfy the policy.
 
-## 7.45 ResultEntityType
+## 7.44 ResultEntityType
 
 A `ResultEntityType` object contains a sequence of `AttributeType` objects reflecting `RequestAttributeType` objects in a given attribute category from the request that had their `IncludeInResult` properties set to `true`. The `ResultEntityType` objects only appear in a result.
 
@@ -5457,7 +5428,7 @@ A `ResultEntityType` object contains the following properties:
 
 <a name="entitytype"></a>
 
-## 7.46 EntityType
+## 7.45 EntityType
 
 The `EntityType` object class defines the structure of values of the `urn:oasis:names:tc:acal:1.0:data-type:entity` data type. An `EntityType` object contains a sequence of `AttributeType` objects and/or syntax-specific content (i.e., XML or JSON). The `EntityType` object type is similar to the `RequestEntityType` object type but omits the `Category` property; values of the `urn:oasis:names:tc:acal:1.0:data-type:entity` data type don't self-identify with any particular attribute category.
 
@@ -5486,7 +5457,7 @@ An `EntityType` object contains the following properties:
 
 : A sequence of `AttributeType` objects.
 
-## 7.47 BundleType
+## 7.46 BundleType
 
 A `BundleType` object type collects together the policies, short identifier sets and shared variables that a PDP uses to evaluate an authorization request along with the starting point for that evaluation. A PDP is said to be defined by a `BundleType` object, although an implementation is not required to physically represent such an object.
 
@@ -5531,7 +5502,7 @@ A `BundleType` object contains the following properties:
 : If present, a `PolicyReferenceType` object that MUST reference a policy in the `Policy` property. A PDP defined by this `BundleType` object SHALL evaluate every authorization request by evaluating this policy reference (the referenced policy is the entry point of evaluation). See [Section 8.13](#813-policyreference-evaluation). If this property is absent, then the PDP returns `NotApplicable` for every authorization request. The policy reference MUST specify arguments if the referenced policy is parameterized.
 
 
-## 7.48 ArgumentType and NamedArgumentType
+## 7.47 ArgumentType and NamedArgumentType
 
 The `ArgumentType` object class is the generic type for all kinds of argument expressions passed to function calls (`ApplyType` objects), parameterized policies (`PolicyType` objects) and shared variables (`SharedVariableDefinitionType` objects). It may be either a simple expression (`ExpressionType` object) or a *named argument* (`NamedArgumentType` object).
 
@@ -5946,7 +5917,7 @@ The absence of matching attributes in the request context for any of the attribu
 
 `urn:oasis:names:tc:acal:1.0:status:missing-attribute`
 
-SHALL be used, to indicate that more information is needed in order for a definitive decision to be rendered. In this case, the `StatusType` object MAY list the names and data types of any attributes that are needed by the PDP to refine its decision (see [Section 7.44](#missingattributedetailtype)). A PEP MAY resubmit a refined request context in response to a `Decision` property value of `Indeterminate` with a status code of
+SHALL be used, to indicate that more information is needed in order for a definitive decision to be rendered. In this case, the `StatusType` object MAY list the names and data types of any attributes that are needed by the PDP to refine its decision (see [Section 7.43](#missingattributedetailtype)). A PEP MAY resubmit a refined request context in response to a `Decision` property value of `Indeterminate` with a status code of
 
 `urn:oasis:names:tc:acal:1.0:status:missing-attribute`
 
@@ -6271,7 +6242,6 @@ The implementation MUST support the object types that are marked `M`. Abstract t
 | QuantifiedExpressionType | O | ForAll, ForAny, Map, Select |
 | RequestAttributeType | M | RequestAttribute |
 | RequestDefaultsType | O | RequestDefaults |
-| RequestEntityReferenceType | O | RequestEntityReference |
 | RequestEntityType | M | RequestEntity |
 | RequestReferenceType | O | RequestReference |
 | RequestType | M | Request |
@@ -7034,7 +7004,7 @@ where `portnumber` is a decimal port number. If the port number is of the form `
 
 ### C.2.6 Entity
 
-The `urn:oasis:names:tc:acal:1.0:data-type:entity` data type is used to represent an entity nested within another entity. Values of this data type are objects of the `EntityType` object type [Section 7.46](#entitytype).
+The `urn:oasis:names:tc:acal:1.0:data-type:entity` data type is used to represent an entity nested within another entity. Values of this data type are objects of the `EntityType` object type [Section 7.45](#entitytype).
 
 ## C.3 Functions
 
@@ -8266,7 +8236,7 @@ This identifier indicates success:
 
 `urn:oasis:names:tc:acal:1.0:status:ok`
 
-This identifier indicates that all the attributes necessary to make a policy decision were not available (see [Section 7.44](#missingattributedetailtype)):
+This identifier indicates that all the attributes necessary to make a policy decision were not available (see [Section 7.43](#missingattributedetailtype)):
 
 `urn:oasis:names:tc:acal:1.0:status:missing-attribute`
 

--- a/acal-core-xml-v4.0-schema.xsd
+++ b/acal-core-xml-v4.0-schema.xsd
@@ -27,7 +27,7 @@
 		<xs:keyref name="Request_RequestEntityReference" refer="xacml:Request_RequestEntity_Id">
 			<xs:selector
 				xpath="xacml:MultiRequests/xacml:RequestReference/xacml:RequestEntityReference" />
-			<xs:field xpath="@Id" />
+			<xs:field xpath="." />
 		</xs:keyref>
 	</xs:element>
 	<xs:complexType name="RequestType">
@@ -377,10 +377,10 @@ which is to be used in Results (no Content or IncludeInResult attributes).
 			<xs:element ref="xacml:RequestReference" maxOccurs="unbounded" />
 		</xs:sequence>
 		<xs:assert vc:minVersion="1.1"
-			test="every $elt in xacml:RequestReference satisfies (every $following in $elt/following-sibling::xacml:RequestReference satisfies count($elt/xacml:RequestEntityReference) != count($following/xacml:RequestEntityReference) or (some $id in $elt/xacml:RequestEntityReference/@Id satisfies not($id = $following/xacml:RequestEntityReference/@Id)))">
+			test="every $elt in xacml:RequestReference satisfies (every $following in $elt/following-sibling::xacml:RequestReference satisfies count($elt/xacml:RequestEntityReference) != count($following/xacml:RequestEntityReference) or (some $id in $elt/xacml:RequestEntityReference satisfies not($id = $following/xacml:RequestEntityReference)))">
 			<xs:annotation>
 				<xs:documentation xml:lang="en"> ACAL constraint on RequestReference property: {OCL}
-					self->isUnique(RequestEntityReference->collect(Id)->asSet()) </xs:documentation>
+					self->isUnique(RequestEntityReference->asSet()) </xs:documentation>
 			</xs:annotation>
 		</xs:assert>
 	</xs:complexType>
@@ -395,14 +395,11 @@ which is to be used in Results (no Content or IncludeInResult attributes).
 	</xs:complexType>
 
 	<!-- Change to XACML 3.0 (issue #18): Attributes renamed to RequestEntity in the Request,
-	therefore AttributesReference renamed to RequestEntityReference for consistency -->
-	<xs:element name="RequestEntityReference" type="xacml:RequestEntityReferenceType" />
-	<xs:complexType name="RequestEntityReferenceType">
-		<!-- Change to XACML 3.0 (issue #62): ReferenceId attribute renamed to Id for simplicity and
-		type aligned with other "local" identifiers (RuleId, VariableId, etc.) and portable to other
-		representation formats like JSON. -->
-		<xs:attribute name="Id" type="xacml:LocalIdentifierType" use="required" />
-	</xs:complexType>
+	therefore AttributesReference renamed to RequestEntityReference for consistency.
+	Change to XACML 4.0 (issue #101): RequestEntityReferenceType removed as an unnecessary
+	wrapper around its single Id property; RequestEntityReference is now typed directly as
+	LocalIdentifierType. -->
+	<xs:element name="RequestEntityReference" type="xacml:LocalIdentifierType" />
 
 	<!-- Change to XACML 3.0 (issue #6): Merged Obligation/Advice(Expression) into
 	Notice(Expression) -->
@@ -523,7 +520,7 @@ which is to be used in Results (no Content or IncludeInResult attributes).
 
 	<!-- Change to XACML 3.0 (issue #61): Simple type for local identifiers in general i.e.
 	identifiers that are unique only locally, such as Request-local identifiers (e.g.
-	RequestEntity/@Id and RequestEntityReference/@Id), Policy-local identifiers (e.g. a policy's
+	RequestEntity/@Id and RequestEntityReference), Policy-local identifiers (e.g. a policy's
 	variable ID (VariableId) or
 	parameter name, or RuleId), Rule-local identifiers (e.g. a rule's variable ID), etc. 
 	-->

--- a/acal-core-xml-v4.0-schematron.sch
+++ b/acal-core-xml-v4.0-schematron.sch
@@ -125,12 +125,12 @@
 	</rule>
  </pattern>
  <pattern id="ACAL_constraint_on_RequestReference_property">
- 	<title>ACAL constraint on RequestReference property: {OCL} self-&gt;isUnique(RequestEntityReference-&gt;collect(Id)-&gt;asSet())</title>
-	<rule context="xacml:MultiRequests"> 
-		<!-- 
-		XSD assertion: for every RequestReference element $elt and every following sibling $following, either the number of RequestEntityReferences in $elt and $following differ or there is some $id in $elt/xacml:RequestEntityReference/@Id that is not in $following/xacml:RequestEntityReference/@Id.
+ 	<title>ACAL constraint on RequestReference property: {OCL} self-&gt;isUnique(RequestEntityReference-&gt;asSet())</title>
+	<rule context="xacml:MultiRequests">
+		<!--
+		XSD assertion: for every RequestReference element $elt and every following sibling $following, either the number of RequestEntityReferences in $elt and $following differ or there is some $id in $elt/xacml:RequestEntityReference that is not in $following/xacml:RequestEntityReference.
 		Reminder: in XPath, Seq1 = Seq2 is true if and only if at least one value from Seq1 is equal to a value in Seq2 -->
-	  <assert test="every $elt in xacml:RequestReference satisfies (every $following in $elt/following-sibling::xacml:RequestReference satisfies count($elt/xacml:RequestEntityReference) != count($following/xacml:RequestEntityReference) or (some $id in $elt/xacml:RequestEntityReference/@Id satisfies not($id = $following/xacml:RequestEntityReference/@Id)))"></assert>
+	  <assert test="every $elt in xacml:RequestReference satisfies (every $following in $elt/following-sibling::xacml:RequestReference satisfies count($elt/xacml:RequestEntityReference) != count($following/xacml:RequestEntityReference) or (some $id in $elt/xacml:RequestEntityReference satisfies not($id = $following/xacml:RequestEntityReference)))"></assert>
 	</rule>
  </pattern>
  <pattern id="ACAL_constraint_on_NoticeExpressionType_AttributeAssignmentExpression_property">

--- a/acal-core-yaml-v1.0-constraints.yaml
+++ b/acal-core-yaml-v1.0-constraints.yaml
@@ -36,6 +36,8 @@ EvaluationModel:
 RuleKinds:
   uniqueByProperty:
     Meaning: "Values in a collection are unique by one or more named child properties."
+  uniqueByValue:
+    Meaning: "Values in a collection of primitive-typed values are unique by their own scalar value."
   uniqueByConcreteSubtype:
     Meaning: "No two values in a collection denote the same effective concrete subtype."
   uniqueByDerivedSet:
@@ -279,15 +281,14 @@ Rule:
       ACALSection: "7.35"
 
   - Id: "requestreference-requestentityreference-id-unique"
-    Kind: uniqueByProperty
+    Kind: uniqueByValue
     Severity: error
     AppliesTo:
       ObjectType: RequestReferenceType
       CollectionPath: "$.Request.MultiRequests.RequestReference[].RequestEntityReference"
-    KeyProperties:
-      - Id
     Requirement: >
-      Id values in a single RequestReferenceType MUST be unique.
+      RequestEntityReference values in a single RequestReferenceType MUST
+      be unique.
     Provenance:
       YACALSection: "5.8.5"
       ACALSection: "7.39"
@@ -297,15 +298,15 @@ Rule:
     Severity: error
     AppliesTo:
       ObjectType: RequestReferenceType
-      ReferencePath: "$.Request.MultiRequests.RequestReference[].RequestEntityReference[].Id"
+      ReferencePath: "$.Request.MultiRequests.RequestReference[].RequestEntityReference[]"
       TargetCollectionPath: "$.Request.RequestEntity"
       TargetKeyProperty: Id
     Requirement: >
-      Each RequestEntityReference Id MUST identify a RequestEntityType in
-      the enclosing Request.
+      Each RequestEntityReference value MUST identify a RequestEntityType
+      in the enclosing Request by the value of its Id property.
     Provenance:
       YACALSection: "5.8.5"
-      ACALSection: "7.40"
+      ACALSection: "7.39"
 
   - Id: "multirequests-requestreference-unique-by-entity-id-set"
     Kind: uniqueByDerivedSet
@@ -313,7 +314,7 @@ Rule:
     AppliesTo:
       ObjectType: MultiRequestsType
       CollectionPath: "$.Request.MultiRequests.RequestReference"
-      DerivedSetPath: RequestEntityReference[].Id
+      DerivedSetPath: RequestEntityReference[]
     Requirement: >
       The set of referenced RequestEntity identifiers in each
       RequestReference MUST be unique within the enclosing MultiRequests

--- a/acal-core-yaml-v1.0-structure.schema.yaml
+++ b/acal-core-yaml-v1.0-structure.schema.yaml
@@ -810,15 +810,6 @@ $defs:
         $ref: "#/$defs/PolicyReferenceType"
     additionalProperties: false
 
-  RequestEntityReferenceType:
-    type: object
-    required:
-      - Id
-    properties:
-      Id:
-        $ref: "#/$defs/LocalIdentifierType"
-    additionalProperties: false
-
   RequestReferenceType:
     type: object
     required:
@@ -827,7 +818,7 @@ $defs:
       RequestEntityReference:
         type: array
         items:
-          $ref: "#/$defs/RequestEntityReferenceType"
+          $ref: "#/$defs/LocalIdentifierType"
         minItems: 1
     additionalProperties: false
 

--- a/acal-core-yaml-v1.0.md
+++ b/acal-core-yaml-v1.0.md
@@ -1812,7 +1812,7 @@ by the relevant ACAL profile, following the generic rules in
 
 If `RequestEntity.Id` values are present, they MUST be unique within the
 enclosing request.  These identifiers are the targets of
-`RequestEntityReferenceType` when the optional multi-request feature is
+`RequestEntityReference` values when the optional multi-request feature is
 used.
 
 ### 5.8.2 RequestEntityType
@@ -1885,13 +1885,13 @@ attribute defines `DataType`, nested values SHOULD omit their own
 MultiRequests:
   RequestReference:
     - RequestEntityReference:
-        - Id: subject-entity-1
-        - Id: action-entity-1
-        - Id: resource-entity-1
+        - subject-entity-1
+        - action-entity-1
+        - resource-entity-1
     - RequestEntityReference:
-        - Id: subject-entity-2
-        - Id: action-entity-1
-        - Id: resource-entity-1
+        - subject-entity-2
+        - action-entity-1
+        - resource-entity-1
 ```
 
 Properties:
@@ -1916,39 +1916,22 @@ rules.
 ```yaml
 RequestReference:
   - RequestEntityReference:
-      - Id: subject-entity-1
-      - Id: action-entity-1
-      - Id: resource-entity-1
+      - subject-entity-1
+      - action-entity-1
+      - resource-entity-1
 ```
 
 Properties:
 
 | Property | Required | Type | Cardinality |
 |---|---|---|---|
-| `RequestEntityReference` | Yes | `RequestEntityReferenceType` | 1..* |
+| `RequestEntityReference` | Yes | `LocalIdentifierType` | 1..* |
 
-Each referenced `Id` MUST identify a `RequestEntityType` object in the
-enclosing `Request`, and the `Id` values in a single
-`RequestReferenceType` object MUST be unique.
+Each `RequestEntityReference` value MUST identify a `RequestEntityType`
+object in the enclosing `Request` by the value of its `Id` property, and
+the values in a single `RequestReferenceType` object MUST be unique.
 
-### 5.8.6 RequestEntityReferenceType
-
-```yaml
-RequestEntityReference:
-  - Id: subject-entity-1
-  - Id: action-entity-1
-```
-
-Properties:
-
-| Property | Required | Type | Cardinality |
-|---|---|---|---|
-| `Id` | Yes | `LocalIdentifierType` | 1 |
-
-The `Id` value references the `Id` property of a `RequestEntityType`
-object in the enclosing `Request`.
-
-### 5.8.7 ResponseType
+### 5.8.6 ResponseType
 
 ```yaml
 Response:
@@ -1976,7 +1959,7 @@ Properties:
 YACAL permits multiple `Result` values in a `Response`, which is
 especially relevant when the optional multi-request feature is used.
 
-### 5.8.8 ResultType
+### 5.8.7 ResultType
 
 Properties:
 
@@ -1993,7 +1976,7 @@ processor that supports this feature SHOULD populate
 `ApplicablePolicyReference` with the identifiers of policies found to be
 applicable to the request.
 
-### 5.8.9 ResultEntityType
+### 5.8.8 ResultEntityType
 
 ```yaml
 ResultEntity:
@@ -2020,7 +2003,7 @@ Unlike `RequestEntityType`, `ResultEntityType` has no `Content`
 property, and its contained `Attribute` objects have no
 `IncludeInResult` property.
 
-### 5.8.10 ApplicablePolicyReference
+### 5.8.9 ApplicablePolicyReference
 
 `ApplicablePolicyReference` values use the direct mapping of
 `ExactMatchIdReferenceType`:
@@ -2042,7 +2025,7 @@ Each item identifies a specific policy version that was applicable to
 the request.  The `Id` value is a policy identifier URI and `Version`
 is a required `VersionType` value for that exact match.
 
-### 5.8.11 RequestDefaultsType
+### 5.8.10 RequestDefaultsType
 
 `RequestDefaultsType` is an optional abstract extension point.  ACAL
 core defines no concrete `RequestDefaultsType` subtype, so YACAL core


### PR DESCRIPTION
RequestEntityReferenceType wrapped a single Id property with no other state, contrary to the model's own convention for primitive-typed multi-valued properties (§3182). RequestReferenceType.RequestEntityReference is now typed directly as LocalIdentifierType [1..*], and RequestEntityReferenceType is removed.

Updated across all representations: ACAL model (§7.39, renumbering §7.40-48 down by one), XML schema/schematron, YACAL doc/constraints/ structure schema, and JACAL JSON schema (missed in an earlier pass, caught on review).