### PR TITLE
Issue #99: lift notice (AttributeId, Category) uniqueness; fix JACAL …

### DIFF
--- a/acal-adoption-guide.md
+++ b/acal-adoption-guide.md
@@ -1062,18 +1062,22 @@ Rule:
   attribute designator, or an apply expression. Note that `Expression` is the
   property name within `AttributeAssignmentExpression` (singular, one expression
   per assignment), distinct from the `Argument` array used by `Apply`.
-- `AttributeAssignmentExpression` items within a `NoticeExpression` MUST be unique
-  by the `(AttributeId, Category)` pair. `Category` is optional on
-  `AttributeAssignmentExpression`; when absent it participates in the uniqueness
-  check as an absent value — meaning two entries with the same `AttributeId` and no
-  `Category` both present would violate the constraint.
-- `NoticeExpression` Ids are **not** required to be unique within a `Policy` or `Rule`.
+- `AttributeAssignmentExpression` items within a `NoticeExpression` are **not** required
+  to be unique by the `(AttributeId, Category)` pair, as they were not in XACML 3.0. Whether
+  a given notice accepts repeated attribute assignments, and how the PEP combines them, is
+  part of the definition of that individual obligation or advice, not of ACAL itself. Note
+  that a single `AttributeAssignmentExpression` evaluating to a bag already produces one
+  `AttributeAssignment` per bag value, all sharing the same pair.
+- Even so, where a notice argument is logically a single value assembled from several parts,
+  prefer building it into one assignment with `string-concatenate` rather than emitting
+  several assignments that the PEP must reassemble. Neither the order of attribute
+  assignments nor the order of values within a bag is guaranteed to be preserved, so the
+  single-value form is unambiguous. See the Rule 3 example in [[ACAL-Core](#acal-core)].
+- `NoticeExpression` Ids are likewise **not** required to be unique within a `Policy` or `Rule`.
   The `Id` identifies what the notice *means* to the PEP — what it must do, or is being
   informed of — exactly as `ObligationId` did in XACML 3.0. It is a *concept* identifier,
   not an instance identifier, so a policy MAY emit the same notice `Id` more than once with
-  different `AttributeAssignmentExpression`s. The uniqueness constraint that *does* apply is
-  on `(AttributeId, Category)` pairs **within** a single notice, not on notice Ids across the
-  enclosing policy or rule.
+  different `AttributeAssignmentExpression`s.
 
 ---
 

--- a/acal-core-json-v1.0-schema.json
+++ b/acal-core-json-v1.0-schema.json
@@ -1093,7 +1093,7 @@
 					"$ref": "#/$defs/BooleanExpressionType"
 				},
 				"AttributeAssignmentExpression": {
-					"$comment": "TODO: add 'uniqueKeys': ['/AttributeId', '/Category'] from ArrayExt vocabulary - https://docs.json-everything.net/schema/vocabs/array-ext/",
+					"$comment": "Issue #99: the (AttributeId, Category) pair is not required to be unique. Whether a notice accepts repeated attribute assignments, and how they combine, is left to the definition of the individual obligation or advice.",
 					"type": "array",
 					"minItems": 1,
 					"items": {
@@ -1117,7 +1117,7 @@
 					"type": "boolean"
 				},
 				"AttributeAssignment": {
-					"$comment": "TODO: add 'uniqueKeys': ['/AttributeId', '/Category'] from ArrayExt vocabulary - https://docs.json-everything.net/schema/vocabs/array-ext/",
+					"$comment": "Issue #99: the (AttributeId, Category) pair is not required to be unique. Whether a notice accepts repeated attribute assignments, and how they combine, is left to the definition of the individual obligation or advice.",
 					"type": "array",
 					"minItems": 1,
 					"items": {

--- a/acal-core-v1.0.md
+++ b/acal-core-v1.0.md
@@ -2766,7 +2766,9 @@ Rule 3 illustrates the use of a notice expression.
 
 [103] - [112] The first attribute assignment indicates the recipient email address, which is obtained from the `urn:oasis:names:tc:acal:1.0:example:attribute:patient-contact` resource attribute using an attribute designator.
 
-[113] - [137] The second attribute assignment provides the email body text. Since a single `AttributeAssignmentExpression` may only assign one value per `(AttributeId, Category)` pair, the literal prefix and the identity of the physician (obtained from the `urn:oasis:names:tc:acal:1.0:subject:subject-id` subject attribute using an attribute designator) are combined into a single value with the `urn:oasis:names:tc:acal:1.0:function:string-concatenate` function. The attribute designator returns a bag of attribute values but `string-concatenate` takes arguments that are single string values, so the designator is wrapped in the `string-one-and-only` function to reduce the bag to a single value.
+[113] - [137] The second attribute assignment provides the email body text. The literal prefix and the identity of the physician (obtained from the `urn:oasis:names:tc:acal:1.0:subject:subject-id` subject attribute using an attribute designator) are combined into a single value with the `urn:oasis:names:tc:acal:1.0:function:string-concatenate` function. The attribute designator returns a bag of attribute values but `string-concatenate` takes arguments that are single string values, so the designator is wrapped in the `string-one-and-only` function to reduce the bag to a single value.
+
+A notice expression is not required to keep its attribute assignments unique by the `(AttributeId, Category)` pair, so the body text could instead have been supplied as two separate assignments sharing the `text` `AttributeId`. Constructing the complete value in a single assignment, as shown here, is nevertheless the recommended practice: neither the order of attribute assignments within a notice nor the order of values within a bag is guaranteed to be preserved, so composing the value in the policy leaves no ambiguity for the PEP to resolve. Where a notice does accept repeated assignments, it is the definition of that individual obligation or advice — not this specification — that states how they are to be interpreted.
 
 #### 6.2.4.4 Rule 4
 
@@ -4789,7 +4791,7 @@ hide circle
 class NoticeType <<dataType>> {
    {field} + Id: IdentifierType [1]
    {field} + IsObligation: Boolean [0..1] = false
-   {field} + AttributeAssignment: AttributeAssignmentType [*] {ordered, unique} {{OCL} self->isUnique(Sequence{AttributeId, Category})}
+   {field} + AttributeAssignment: AttributeAssignmentType [*] {ordered, nonunique}
 }
 @enduml
 ```
@@ -4894,7 +4896,7 @@ class NoticeExpressionType <<dataType>> {
   {field} + IsObligation: Boolean [0..1] = false
   {field} + AppliesTo: EffectType [0..1]
   {field} + Condition: BooleanExpressionType [0..1]
-  {field} + AttributeAssignmentExpression: AttributeAssignmentExpressionType [*] {ordered, unique} {{OCL} self->isUnique(Sequence{AttributeId, Category})}
+  {field} + AttributeAssignmentExpression: AttributeAssignmentExpressionType [*] {ordered, nonunique}
 }
 @enduml
 ```

--- a/acal-core-xml-v4.0-schema.xsd
+++ b/acal-core-xml-v4.0-schema.xsd
@@ -403,14 +403,10 @@ which is to be used in Results (no Content or IncludeInResult attributes).
 
 	<!-- Change to XACML 3.0 (issue #6): Merged Obligation/Advice(Expression) into
 	Notice(Expression) -->
-	<xs:element name="Notice" type="xacml:NoticeType">
-		<xs:unique name="Notice_AttributeAssignment_AttributeId-Category">
-			<xs:selector xpath="xacml:AttributeAssignment" />
-			<xs:field xpath="@AttributeId" />
-			<!-- Note that this does not prevent duplicate AttributeId if Category not present -->
-			<xs:field xpath="@Category" />
-		</xs:unique>
-	</xs:element>
+	<!-- Issue #99: AttributeAssignment is no longer constrained to be unique by the (AttributeId,
+	Category) pair. Whether a notice accepts repeated attribute assignments, and how they combine,
+	is left to the definition of the individual obligation or advice, as it was in XACML 3.0. -->
+	<xs:element name="Notice" type="xacml:NoticeType" />
 	<xs:complexType name="NoticeType">
 		<xs:sequence>
 			<xs:element ref="xacml:AttributeAssignment" minOccurs="0" maxOccurs="unbounded" />
@@ -419,17 +415,6 @@ which is to be used in Results (no Content or IncludeInResult attributes).
 		Short Identifiers -->
 		<xs:attribute name="Id" type="xacml:IdentifierType" use="required" />
 		<xs:attribute name="IsObligation" type="xs:boolean" use="optional" default="false" />
-		<!-- Issue #102: xs:unique cannot express uniqueness over a key that includes an optional
-		field, so it does not catch duplicate AttributeId when Category is absent from both. This
-		assert covers that case; XSD 1.0 processors must rely on the Schematron rule instead. -->
-		<xs:assert vc:minVersion="1.1"
-			test="every $elt in xacml:AttributeAssignment satisfies (every $following in $elt/following-sibling::xacml:AttributeAssignment satisfies not($elt/@AttributeId = $following/@AttributeId and ((not($elt/@Category) and not($following/@Category)) or $elt/@Category = $following/@Category)))">
-			<xs:annotation>
-				<xs:documentation xml:lang="en"> ACAL constraint on Notice property: {OCL}
-					self->isUnique(AttributeAssignment->collect(Sequence{AttributeId, Category}))
-					</xs:documentation>
-			</xs:annotation>
-		</xs:assert>
 	</xs:complexType>
 
 	<xs:element name="AttributeAssignment" type="xacml:AttributeAssignmentType" />
@@ -449,15 +434,12 @@ which is to be used in Results (no Content or IncludeInResult attributes).
 
 	<!-- Change to XACML 3.0 (issue #6): Merged Obligation/Advice(Expression) into
 	Notice(Expression) -->
-	<xs:element name="NoticeExpression" type="xacml:NoticeExpressionType">
-		<xs:unique name="NoticeExpression_AttributeAssignmentExpression_AttributeId-Category">
-			<xs:selector xpath="xacml:AttributeAssignmentExpression" />
-			<xs:field xpath="@AttributeId" />
-			<!-- Note that this does not prevent duplicate AttributeId if Category (optional) not
-			present -->
-			<xs:field xpath="@Category" />
-		</xs:unique>
-	</xs:element>
+	<!-- Issue #99: AttributeAssignmentExpression is no longer constrained to be unique by the
+	(AttributeId, Category) pair. Whether a notice accepts repeated attribute assignments, and how
+	they combine, is left to the definition of the individual obligation or advice, as it was in
+	XACML 3.0. Note also that a single AttributeAssignmentExpression evaluating to a bag already
+	produces one AttributeAssignment per bag value, all sharing the same (AttributeId, Category). -->
+	<xs:element name="NoticeExpression" type="xacml:NoticeExpressionType" />
 	<xs:complexType name="NoticeExpressionType">
 		<xs:sequence>
 			<xs:element ref="xacml:Condition" minOccurs="0" />
@@ -474,17 +456,6 @@ which is to be used in Results (no Content or IncludeInResult attributes).
 					and Deny. </xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
-		<!-- Issue #99: xs:unique cannot express uniqueness over a key that includes an optional
-		field, so it does not catch duplicate AttributeId when Category is absent from both. This
-		assert covers that case; XSD 1.0 processors must rely on the Schematron rule instead. -->
-		<xs:assert vc:minVersion="1.1"
-			test="every $elt in xacml:AttributeAssignmentExpression satisfies (every $following in $elt/following-sibling::xacml:AttributeAssignmentExpression satisfies not($elt/@AttributeId = $following/@AttributeId and ((not($elt/@Category) and not($following/@Category)) or $elt/@Category = $following/@Category)))">
-			<xs:annotation>
-				<xs:documentation xml:lang="en"> ACAL constraint on NoticeExpression property:
-					{OCL} self->isUnique(AttributeAssignmentExpression->collect(Sequence{AttributeId,
-					Category})) </xs:documentation>
-			</xs:annotation>
-		</xs:assert>
 	</xs:complexType>
 
 	<xs:element name="AttributeAssignmentExpression" type="xacml:AttributeAssignmentExpressionType" />

--- a/acal-core-xml-v4.0-schematron.sch
+++ b/acal-core-xml-v4.0-schematron.sch
@@ -133,24 +133,11 @@
 	  <assert test="every $elt in xacml:RequestReference satisfies (every $following in $elt/following-sibling::xacml:RequestReference satisfies count($elt/xacml:RequestEntityReference) != count($following/xacml:RequestEntityReference) or (some $id in $elt/xacml:RequestEntityReference satisfies not($id = $following/xacml:RequestEntityReference)))"></assert>
 	</rule>
  </pattern>
- <pattern id="ACAL_constraint_on_NoticeExpressionType_AttributeAssignmentExpression_property">
- 	<title>ACAL constraint on NoticeExpressionType property: {OCL} self-&gt;isUnique(AttributeAssignmentExpression-&gt;collect(Sequence{AttributeId, Category}))</title>
-	<rule context="xacml:NoticeExpression">
-		<!--
-		Issue #99: complements the XSD's xs:unique constraint, which cannot catch a duplicate
-		AttributeId when Category is absent from both AttributeAssignmentExpression elements.
-		-->
-	  <assert test="every $elt in xacml:AttributeAssignmentExpression satisfies (every $following in $elt/following-sibling::xacml:AttributeAssignmentExpression satisfies not($elt/@AttributeId = $following/@AttributeId and ((not($elt/@Category) and not($following/@Category)) or $elt/@Category = $following/@Category)))">Duplicate AttributeAssignmentExpression (AttributeId, Category) pair</assert>
-	</rule>
- </pattern>
- <pattern id="ACAL_constraint_on_NoticeType_AttributeAssignment_property">
- 	<title>ACAL constraint on NoticeType property: {OCL} self-&gt;isUnique(AttributeAssignment-&gt;collect(Sequence{AttributeId, Category}))</title>
-	<rule context="xacml:Notice">
-		<!--
-		Issue #102: complements the XSD's xs:unique constraint, which cannot catch a duplicate
-		AttributeId when Category is absent from both AttributeAssignment elements.
-		-->
-	  <assert test="every $elt in xacml:AttributeAssignment satisfies (every $following in $elt/following-sibling::xacml:AttributeAssignment satisfies not($elt/@AttributeId = $following/@AttributeId and ((not($elt/@Category) and not($following/@Category)) or $elt/@Category = $following/@Category)))">Duplicate AttributeAssignment (AttributeId, Category) pair</assert>
-	</rule>
- </pattern>
+ <!--
+ Issue #99: the patterns that enforced (AttributeId, Category) uniqueness on
+ NoticeExpression/AttributeAssignmentExpression and Notice/AttributeAssignment have been removed.
+ Those pairs are no longer required to be unique; whether a notice accepts repeated attribute
+ assignments, and how they combine, is left to the definition of the individual obligation or
+ advice, as it was in XACML 3.0.
+ -->
 </schema>

--- a/acal-core-yaml-v1.0-constraints.yaml
+++ b/acal-core-yaml-v1.0-constraints.yaml
@@ -500,39 +500,11 @@ Rule:
       YACALSection: "5.6.6"
       ACALSection: "7.11"
 
-  - Id: "noticeexpression-attributeassignmentexpression-unique"
-    Kind: uniqueByProperty
-    Severity: error
-    AppliesTo:
-      ObjectType: NoticeExpressionType
-      CollectionPath: "$..NoticeExpression[].AttributeAssignmentExpression"
-    KeyProperties:
-      - AttributeId
-      - Category
-    Requirement: >
-      AttributeAssignmentExpression values within a NoticeExpressionType
-      MUST be unique by the (AttributeId, Category) pair. An absent
-      Category participates in the pair as an absent value.
-    Provenance:
-      YACALSection: "5.9.1"
-      ACALSection: "7.29"
-
-  - Id: "notice-attributeassignment-unique"
-    Kind: uniqueByProperty
-    Severity: error
-    AppliesTo:
-      ObjectType: NoticeType
-      CollectionPath: "$.Response.Result[].Notice[].AttributeAssignment"
-    KeyProperties:
-      - AttributeId
-      - Category
-    Requirement: >
-      AttributeAssignment values within a NoticeType MUST be unique by the
-      (AttributeId, Category) pair. An absent Category participates in the
-      pair as an absent value.
-    Provenance:
-      YACALSection: "5.9.3"
-      ACALSection: "7.26"
+  # Issue #99: "noticeexpression-attributeassignmentexpression-unique" (ACAL 7.29) and
+  # "notice-attributeassignment-unique" (ACAL 7.26) were removed. The (AttributeId, Category)
+  # pair is no longer required to be unique within a NoticeExpression or a Notice; whether a
+  # notice accepts repeated attribute assignments, and how they combine, is left to the
+  # definition of the individual obligation or advice, as it was in XACML 3.0.
 
   - Id: "result-resultentity-category-unique"
     Kind: uniqueByProperty

--- a/acal-core-yaml-v1.0.md
+++ b/acal-core-yaml-v1.0.md
@@ -2083,8 +2083,10 @@ Properties:
 If `AppliesTo` is omitted, the notice expression is eligible for either
 `Permit` or `Deny`.
 
-`AttributeAssignmentExpression` items MUST be unique by the pair
-`(AttributeId, Category)`, as defined for `NoticeExpressionType` in
+`AttributeAssignmentExpression` items are not required to be unique by the pair
+`(AttributeId, Category)`. Whether a given notice accepts repeated attribute
+assignments, and how a consumer combines them, is left to the definition of the
+individual obligation or advice, as defined for `NoticeExpressionType` in
 [[ACAL-Core](#acal-core)].
 
 ### 5.9.2 AttributeAssignmentExpressionType
@@ -2139,8 +2141,10 @@ Properties:
 | `IsObligation` | No | `false` | Boolean | 0..1 |
 | `AttributeAssignment` | No | — | `AttributeAssignmentType` | * |
 
-`AttributeAssignment` items SHOULD be unique by the pair
-`(AttributeId, Category)`.
+`AttributeAssignment` items are not required to be unique by the pair
+`(AttributeId, Category)`. A single `AttributeAssignmentExpression` evaluating to a
+bag already yields one `AttributeAssignment` per bag value, all sharing the same
+pair.
 
 ### 5.9.4 AttributeAssignmentType
 

--- a/examples/acal-xpath/Request.json
+++ b/examples/acal-xpath/Request.json
@@ -1,16 +1,18 @@
 {
     "Request": {
-        "RequestDefaults": {
-            "XPathRequestDefaults": {
-                "XPathVersion": "https://www.w3.org/TR/xpath20/",
-                "Namespace": [
-                    {
-                        "Prefix": "md",
-                        "Name": "urn:example:med:schemas:record"
-                    }
-                ]
+        "RequestDefaults": [
+            {
+                "XPathRequestDefaults": {
+                    "XPathVersion": "https://www.w3.org/TR/xpath20/",
+                    "Namespace": [
+                        {
+                            "Prefix": "md",
+                            "Name": "urn:example:med:schemas:record"
+                        }
+                    ]
+                }
             }
-        },
+        ],
         "RequestEntity": [
             {
                 "Category": "urn:oasis:names:tc:acal:1.0:subject-category:access-subject",

--- a/examples/acal-xpath/Rule1.json
+++ b/examples/acal-xpath/Rule1.json
@@ -3,28 +3,30 @@
         "PolicyId": "urn:oasis:names:tc:acal:1.0:example:policyid:1",
         "Version": "1.0",
         "CombiningAlgId": "urn:oasis:names:tc:acal:1.0:combining-algorithm:deny-overrides",
-        "PolicyDefaults": {
-            "XPathPolicyDefaults": {
-                "XPathVersion": "https://www.w3.org/TR/xpath20/",
-                "Namespace": [
-                    {
-                        "Prefix": "md",
-                        "Name": "urn:example:med:schemas:record"
-                    }
-                ]
+        "PolicyDefaults": [
+            {
+                "XPathPolicyDefaults": {
+                    "XPathVersion": "https://www.w3.org/TR/xpath20/",
+                    "Namespace": [
+                        {
+                            "Prefix": "md",
+                            "Name": "urn:example:med:schemas:record"
+                        }
+                    ]
+                }
             }
-        },
+        ],
         "VariableDefinition": [
             {
                 "VariableId": "patient_number_matched",
                 "Expression": {
                     "Apply": {
                         "FunctionId": "urn:oasis:names:tc:acal:1.0:function:string-equal",
-                        "Expression": [
+                        "Argument": [
                             {
                                 "Apply": {
                                     "FunctionId": "urn:oasis:names:tc:acal:1.0:function:string-one-and-only",
-                                    "Expression": [
+                                    "Argument": [
                                         {
                                             "AttributeDesignator": {
                                                 "Category": "urn:oasis:names:tc:acal:1.0:subject-category:access-subject",
@@ -37,7 +39,7 @@
                             {
                                 "Apply": {
                                     "FunctionId": "urn:oasis:names:tc:acal:1.0:function:string-one-and-only",
-                                    "Expression": [
+                                    "Argument": [
                                         {
                                             "XPathAttributeSelector": {
                                                 "Category": "urn:oasis:names:tc:acal:1.0:attribute-category:resource",
@@ -61,7 +63,7 @@
                     "Condition": {
                         "Apply": {
                             "FunctionId": "urn:oasis:names:tc:acal:1.0:function:and",
-                            "Expression": [
+                            "Argument": [
                                 {
                                     "VariableReference": {
                                         "VariableId": "patient_number_matched"
@@ -70,7 +72,7 @@
                                 {
                                     "Apply": {
                                         "FunctionId": "urn:oasis:names:tc:acal:1.0:function:string-is-in",
-                                        "Expression": [
+                                        "Argument": [
                                             {
                                                 "Value": "read"
                                             },
@@ -86,7 +88,7 @@
                                 {
                                     "Apply": {
                                         "FunctionId": "urn:oasis:names:tc:acal:1.0:function:anyURI-is-in",
-                                        "Expression": [
+                                        "Argument": [
                                             {
                                                 "Value": "urn:example:med:schemas:record"
                                             },
@@ -102,7 +104,7 @@
                                 {
                                     "Apply": {
                                         "FunctionId": "urn:oasis:names:tc:acal:1.0:function:any-of",
-                                        "Expression": [
+                                        "Argument": [
                                             {
                                                 "Function": {
                                                     "Id": "urn:oasis:names:tc:acal:1.0:function:xpath-node-match"

--- a/examples/acal-xpath/Rule2.json
+++ b/examples/acal-xpath/Rule2.json
@@ -3,28 +3,30 @@
         "PolicyId": "urn:oasis:names:tc:acal:1.0:example:policyid:2",
         "Version": "1.0",
         "CombiningAlgId": "urn:oasis:names:tc:acal:1.0:combining-algorithm:deny-overrides",
-        "PolicyDefaults": {
-            "XPathPolicyDefaults": {
-                "XPathVersion": "https://www.w3.org/TR/xpath20/",
-                "Namespace": [
-                    {
-                        "Prefix": "md",
-                        "Name": "urn:example:med:schemas:record"
-                    }
-                ]
+        "PolicyDefaults": [
+            {
+                "XPathPolicyDefaults": {
+                    "XPathVersion": "https://www.w3.org/TR/xpath20/",
+                    "Namespace": [
+                        {
+                            "Prefix": "md",
+                            "Name": "urn:example:med:schemas:record"
+                        }
+                    ]
+                }
             }
-        },
+        ],
         "VariableDefinition": [
             {
                 "VariableId": "patient_under_16",
                 "Expression": {
                     "Apply": {
                         "FunctionId": "urn:oasis:names:tc:acal:1.0:function:date-less-or-equal",
-                        "Expression": [
+                        "Argument": [
                             {
                                 "Apply": {
                                     "FunctionId": "urn:oasis:names:tc:acal:1.0:function:date-one-and-only",
-                                    "Expression": [
+                                    "Argument": [
                                         {
                                             "AttributeDesignator": {
                                                 "Category": "urn:oasis:names:tc:acal:1.0:attribute-category:environment",
@@ -37,11 +39,11 @@
                             {
                                 "Apply": {
                                     "FunctionId": "urn:oasis:names:tc:acal:1.0:function:date-add-yearMonthDuration",
-                                    "Expression": [
+                                    "Argument": [
                                         {
                                             "Apply": {
                                                 "FunctionId": "urn:oasis:names:tc:acal:1.0:function:date-one-and-only",
-                                                "Expression": [
+                                                "Argument": [
                                                     {
                                                         "XPathAttributeSelector": {
                                                             "Category": "urn:oasis:names:tc:acal:1.0:attribute-category:resource",
@@ -71,7 +73,7 @@
                     "Condition": {
                         "Apply": {
                             "FunctionId": "urn:oasis:names:tc:acal:1.0:function:and",
-                            "Expression": [
+                            "Argument": [
                                 {
                                     "VariableReference": {
                                         "VariableId": "patient_under_16"
@@ -80,7 +82,7 @@
                                 {
                                     "Apply": {
                                         "FunctionId": "urn:oasis:names:tc:acal:1.0:function:string-is-in",
-                                        "Expression": [
+                                        "Argument": [
                                             {
                                                 "Value": "read"
                                             },
@@ -96,7 +98,7 @@
                                 {
                                     "Apply": {
                                         "FunctionId": "urn:oasis:names:tc:acal:1.0:function:anyURI-is-in",
-                                        "Expression": [
+                                        "Argument": [
                                             {
                                                 "Value": "urn:example:med:schemas:record"
                                             },
@@ -112,7 +114,7 @@
                                 {
                                     "Apply": {
                                         "FunctionId": "urn:oasis:names:tc:acal:1.0:function:any-of",
-                                        "Expression": [
+                                        "Argument": [
                                             {
                                                 "Function": {
                                                     "Id": "urn:oasis:names:tc:acal:1.0:function:xpath-node-match"
@@ -136,11 +138,11 @@
                                 {
                                     "Apply": {
                                         "FunctionId": "urn:oasis:names:tc:acal:1.0:function:string-equal",
-                                        "Expression": [
+                                        "Argument": [
                                             {
                                                 "Apply": {
                                                     "FunctionId": "urn:oasis:names:tc:acal:1.0:function:string-one-and-only",
-                                                    "Expression": [
+                                                    "Argument": [
                                                         {
                                                             "AttributeDesignator": {
                                                                 "Category": "urn:oasis:names:tc:acal:1.0:subject-category:access-subject",
@@ -153,7 +155,7 @@
                                             {
                                                 "Apply": {
                                                     "FunctionId": "urn:oasis:names:tc:acal:1.0:function:string-one-and-only",
-                                                    "Expression": [
+                                                    "Argument": [
                                                         {
                                                             "XPathAttributeSelector": {
                                                                 "Category": "urn:oasis:names:tc:acal:1.0:attribute-category:resource",

--- a/examples/acal-xpath/Rule3.json
+++ b/examples/acal-xpath/Rule3.json
@@ -4,21 +4,23 @@
         "Version": "1.0",
         "CombiningAlgId": "urn:oasis:names:tc:acal:1.0:combining-algorithm:deny-overrides",
         "Description": "Policy for any medical record in the urn:example:med:schemas:record namespace",
-        "PolicyDefaults": {
-            "XPathPolicyDefaults": {
-                "XPathVersion": "https://www.w3.org/TR/xpath20/",
-                "Namespace": [
-                    {
-                        "Prefix": "md",
-                        "Name": "urn:example:med:schemas:record"
-                    }
-                ]
+        "PolicyDefaults": [
+            {
+                "XPathPolicyDefaults": {
+                    "XPathVersion": "https://www.w3.org/TR/xpath20/",
+                    "Namespace": [
+                        {
+                            "Prefix": "md",
+                            "Name": "urn:example:med:schemas:record"
+                        }
+                    ]
+                }
             }
-        },
+        ],
         "Target": {
             "Apply": {
                 "FunctionId": "urn:oasis:names:tc:acal:1.0:function:anyURI-is-in",
-                "Expression": [
+                "Argument": [
                     {
                         "Value": "urn:example:med:schemas:record"
                     },
@@ -40,11 +42,11 @@
                     "Condition": {
                         "Apply": {
                             "FunctionId": "urn:oasis:names:tc:acal:1.0:function:and",
-                            "Expression": [
+                            "Argument": [
                                 {
                                     "Apply": {
                                         "FunctionId": "urn:oasis:names:tc:acal:1.0:function:string-is-in",
-                                        "Expression": [
+                                        "Argument": [
                                             {
                                                 "Value": "physician"
                                             },
@@ -60,7 +62,7 @@
                                 {
                                     "Apply": {
                                         "FunctionId": "urn:oasis:names:tc:acal:1.0:function:any-of",
-                                        "Expression": [
+                                        "Argument": [
                                             {
                                                 "Function": {
                                                     "Id": "urn:oasis:names:tc:acal:1.0:function:xpath-node-match"
@@ -84,7 +86,7 @@
                                 {
                                     "Apply": {
                                         "FunctionId": "urn:oasis:names:tc:acal:1.0:function:string-is-in",
-                                        "Expression": [
+                                        "Argument": [
                                             {
                                                 "Value": "write"
                                             },
@@ -100,11 +102,11 @@
                                 {
                                     "Apply": {
                                         "FunctionId": "urn:oasis:names:tc:acal:1.0:function:string-equal",
-                                        "Expression": [
+                                        "Argument": [
                                             {
                                                 "Apply": {
                                                     "FunctionId": "urn:oasis:names:tc:acal:1.0:function:string-one-and-only",
-                                                    "Expression": [
+                                                    "Argument": [
                                                         {
                                                             "AttributeDesignator": {
                                                                 "Category": "urn:oasis:names:tc:acal:1.0:subject-category:access-subject",
@@ -117,7 +119,7 @@
                                             {
                                                 "Apply": {
                                                     "FunctionId": "urn:oasis:names:tc:acal:1.0:function:string-one-and-only",
-                                                    "Expression": [
+                                                    "Argument": [
                                                         {
                                                             "XPathAttributeSelector": {
                                                                 "Category": "urn:oasis:names:tc:acal:1.0:attribute-category:resource",
@@ -157,7 +159,7 @@
                         "Expression": {
                             "Apply": {
                                 "FunctionId": "urn:oasis:names:tc:acal:1.0:function:string-concatenate",
-                                "Expression": [
+                                "Argument": [
                                     {
                                         "Value": "Your medical record has been accessed by: "
                                     },


### PR DESCRIPTION
I brought two issues into one PR because the are both related to #99. The goal of Part 1 is to align with @cdanger's agreement on Option 3 ("lift the uniqueness constraint but keep the example with string-concatenate") and consistent with @steven-legg's analysis. Part 2 aims to fix the set of schema violations in the XPath profile examples that surfaced while reviewing the PR #116 merge.

## Part 1: lift the (AttributeId, Category) uniqueness constraint

The constraint is removed from every artifact that carried it:

- acal-core-v1.0.md 7.26 (NoticeType) and 7.29 (NoticeExpressionType)
- acal-core-xml-v4.0-schema.xsd: the xs:unique identity constraints on the Notice and NoticeExpression elements, and the XSD 1.1 xs:assert blocks added for #99 and #102 that covered the absent-Category case
- acal-core-xml-v4.0-schematron.sch: both ACAL_constraint_on_Notice* patterns
- acal-core-yaml-v1.0-constraints.yaml: the "noticeexpression-attributeassignmentexpression-unique" and "notice-attributeassignment-unique" rules
- acal-core-json-v1.0-schema.json: the two now-moot ArrayExt 'uniqueKeys' TODOs
- prose in acal-core-yaml-v1.0.md 5.9.1/5.9.3 and acal-adoption-guide.md

Beyond the XACML 3.0 precedent argued in the issue, the constraint was self-contradictory as written: 7.29 already states that an AttributeAssignmentExpression evaluating to a bag produces one AttributeAssignment per bag value, all of which necessarily share the same (AttributeId, Category) pair. NoticeType could not both require that pair to be unique and admit the assignments its own evaluation rule generates.

Modelling decision: {ordered, nonunique}
----------------------------------------

The UML field declarations in 7.26 and 7.29 previously read:

  [*] {ordered, unique} {{OCL} self->isUnique(Sequence{AttributeId, Category})}

These carry two separate constraints: whole-object uniqueness ({unique}) and key uniqueness on the (AttributeId, Category) pair (the OCL clause). Both are dropped here, giving:

  [*] {ordered, nonunique}

Rationale for dropping {unique} as well as the OCL clause:

- It matches the sibling collections already declared in the same model. Policy.NoticeExpression, Rule.NoticeExpression, Result.Notice and Policy.CombinerInput are all {ordered, nonunique}; leaving the notice argument lists as {ordered, unique} would make them the odd ones out.
- XACML 3.0 imposed neither constraint on obligation/advice attribute assignments, and the issue concluded there is no technical reason to add one.
- Retaining {unique} would still forbid two byte-identical assignments. Whether that is meaningful is a question for the individual obligation or advice definition, which is exactly where the issue resolved to put it.

***This is the minimal-constraint reading. If the TC prefers to drop only the OCL key constraint and retain whole-object uniqueness, those two lines become {ordered, unique} instead and nothing else in this commit changes.***

The Rule 3 walkthrough in 6.2.4.3 kept its string-concatenate / string-one-and-only form, but its justification was rewritten. It previously read "Since a single AttributeAssignmentExpression may only assign one value per (AttributeId, Category) pair..." -- i.e. it was justified by the very constraint being removed. It is now presented as recommended practice on the grounds @steven-legg actually gave: neither the order of attribute assignments within a notice nor the order of values within a bag is guaranteed to be preserved, so composing the value in the policy leaves no ambiguity for the PEP.

## Part 2: JACAL XPath example schema violations

All four examples/acal-xpath/*.json files failed validation against the core schema composed with the XPath and JSONPath profiles. Two distinct causes:

- Apply used "Expression" for its argument list, but ApplyType defines "Argument" and sets additionalProperties: false. 27 occurrences (Rule1 x7, Rule2 x11, Rule3 x9). This generalises the one-line fix @cdanger applied in 9dfcc05, which corrected a single site and left Rule3.json internally inconsistent.
- PolicyDefaults / RequestDefaults were JSON objects where the schema requires an array. 4 occurrences, one per file.

All four now validate with zero errors. The XML counterparts need no equivalent change: XML flattens the Defaults through substitution groups and Apply arguments are positional elements, so neither defect can arise there.

Worth noting for follow-up: *acal-xpath-json-v1.0-schema.json is $defs-only with *no root constraints**, so validating an instance directly against it silently passes anything. That is most likely why these went unnoticed, and it argues for a CI validation step using a composed root schema.